### PR TITLE
Architecture and placeholders for multiple drafts

### DIFF
--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -373,7 +373,8 @@ MoLE constructions provide three privacy properties.
 3. *Anchor-endorsement post-issuance unlinkability.* A Moderator cannot link an
    Anchor-endorsement presentation to its issuance transcript. Constructions are
    expected to preserve this property against adversaries that record issuance
-   traffic and later gain access to quantum computation.
+   traffic and later gain access to a cryptographically relevant quantum
+   computation.
 
 A successful presentation tells the Site that the Client holds a Moderator
 credential satisfying the Site's policy. It does not reveal the Client's

--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -253,10 +253,6 @@ The following terms are used throughout this document:
 The Client obtains a credential from an Anchor, presents it to a Moderator, and
 uses the resulting Moderator credential when sending requests to a Site.
 
-TODO:
-1. What about state?
-2. What about a client going to the moderator directly (with one RTT) rather than passing by the site
-
 ~~~ aasvg
 +--------+                 +--------+             +-----------+             +------+
 | Client |                 | Anchor |             | Moderator |             | Site |
@@ -301,8 +297,8 @@ EndorsementFinalization        |
 {: #fig-mole-architecture-endorsement title="MoLE Endorsement"}
 
 Upon passing an attestation, a Client may request an Endorsement from an Anchor.
-This is a cryptographic blob that the Client can later present to Moderator that
-proves the Client has been endorsed by the Anchor.
+An Endorsement is a cryptographic object that the client can later present to
+a Moderator that proves the Client has been attested by the Anchor.
 
 ### Credential Issuance
 

--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -60,7 +60,7 @@ Moderation of unLinkable Endorsements (MoLE) is an architecture in which
 Sites make authorization decisions from unlinkable, issuer-hiding credential
 presentations derived from scarce signals.
 
-Users often encounter friction when an Site has little prior context about
+Users often encounter friction when a Site has little prior context about
 them: for example, when they arrive with no cookies, use a VPN, enable
 privacy-preserving browser settings, or delegate browsing to a software agent.
 In those cases, the Site may present a CAPTCHA, use fingerprinting, reject the
@@ -131,7 +131,7 @@ most strongly load-bearing for the second.
 
 ## Reduced-Friction Challenges {#uc-friction}
 
-A user visits an Site for the first time, with no cookies, possibly through a
+A user visits a Site for the first time, with no cookies, possibly through a
 VPN or shared NAT that obscures the network-layer identifier. The Site has no
 per-user history and limited reputational signal from the network path. The
 user is the party who bears the cost of whatever the Site then chooses ---
@@ -153,7 +153,7 @@ admit user agents partially or wholly automated on behalf of the user; see
 
 ## User Agents Acting Under Delegation {#uc-agents}
 
-A user delegates some of their interaction with an Site to an automated agent
+A user delegates some of their interaction with a Site to an automated agent
 running in, or alongside, their browser. Such an agent is a user agent: it acts
 under delegation from a user who could otherwise have driven the browser
 themselves. Sites that lack a richer signal commonly treat the appearance of
@@ -192,7 +192,7 @@ agents is therefore drawn by Anchors and Moderators.
 
 ## Private Access Control {#uc-access}
 
-A user visits an Site repeatedly, without persistent cookies, expecting that
+A user visits a Site repeatedly, without persistent cookies, expecting that
 successive visits are not linkable to one another. The Site gates some
 functionality on a non-public criterion such as a paid subscription, group
 membership, or a per-period quota of allowed operations.
@@ -220,7 +220,7 @@ architecture document but may be included in companion documents.
 The following terms are used throughout this document:
 
 **Client:**
-: An entity that seeks access to resources held by an Site.
+: An entity that seeks access to resources held by a Site.
 
 **Site:**
 : An entity that consumes presentations from Clients and uses them to make
@@ -251,11 +251,11 @@ The following terms are used throughout this document:
 ## Overview
 
 The Client obtains a credential from an Anchor, presents it to a Moderator, and
-uses the resulting Moderator credential when sending requests to an Site.
+uses the resulting Moderator credential when sending requests to a Site.
 
-TODO: should tghis be three diagarms so we can detail things better? Should it be
-like reverse flow privacy pass and then map roles (anchor, moderator) onto flows?
-What about state, which is a key distinction with PP
+TODO:
+1. What about state?
+2. What about a client going to the moderator directly (with one RTT) rather than passing by the site
 
 ~~~ aasvg
 +--------+                 +--------+             +-----------+             +------+
@@ -283,8 +283,7 @@ CredentialFinalization         |                        |                       
 
 ## Flows
 
-TODO: for each flow, provide a succint description
-Similar to {{RFC9576}}, this section does not dive into context creation
+Taking {{fig-mole-architecture}}, we can distinguish three flows.
 
 ### Endorsement
 
@@ -293,12 +292,17 @@ Similar to {{RFC9576}}, this section does not dive into context creation
 | Client |                 | Anchor |
 +---+----+                 +---+----+
     |                          |
+    |<===== Attestation ======>|
     +--- EndorsementRequest -->|
     |<-- EndorsementResponse --+
 EndorsementFinalization        |
     |                          |
 ~~~
 {: #fig-mole-architecture-endorsement title="MoLE Endorsement"}
+
+Upon passing an attestation, a Client may request an Endorsement from an Anchor.
+This is a cryptographic blob that the Client can later present to Moderator that
+proves the Client has been endorsed by the Anchor.
 
 ### Credential Issuance
 
@@ -316,7 +320,12 @@ CredentialFinalization         |                        |
 ~~~
 {: #fig-mole-architecture-issuance title="MoLE Issuance"}
 
-### Credential Presentation
+When an Endorsement is presented to a Moderator, the Moderator learns
+whether or not the Endorsement is part of a set of Anchor it trusts. The
+presentation must not be linkable to a specific Anchor or other presentations of
+that same Endorsement.
+
+### Credential Presentation and updates
 
 ~~~ aasvg
 +--------+               +-----------+             +------+
@@ -334,11 +343,9 @@ CredentialFinalization         |                       |
 ~~~
 {: #fig-mole-architecture-presentation title="MoLE Presentation"}
 
-When a Moderator credential is presented to a Origin, the Origin learns
-whether or not it satisfies an Origin specific policy. The presentation
+When a Moderator credential is presented to a Site, the Site learns
+whether or not it satisfies a Site specific policy. The presentation
 must not be linkable to past updates.
-
-### Credential Updates
 
 Credential updates must demonstrate that they are applied to the same
 credential as was initially presented. This prevents attacks where an
@@ -381,7 +388,7 @@ The properties above are cryptographic properties of the protocol transcript.
 They do not hide information available outside the transcript, such as network
 metadata, request contents, timing, or user-agent fingerprinting.
 
-Collusion changes the privacy properties. For example, an Site and Moderator
+Collusion changes the privacy properties. For example, a Site and Moderator
 that share request timing, network metadata, and validation logs may be able to
 link presentations even when the credential presentation itself is unlinkable.
 Deployment sections describe which entities need to be separated for a given
@@ -401,7 +408,7 @@ that partition Clients into small sets.
 ## State
 
 Moderator credentials can carry policy state, such as quota or revocation state.
-State updates must not give an Site or Moderator a stable handle that links
+State updates must not give a Site or Moderator a stable handle that links
 future presentations by the same Client.
 
 The details are construction-specific. Companion documents need to specify what

--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -317,9 +317,10 @@ CredentialFinalization         |                        |
 {: #fig-mole-architecture-issuance title="MoLE Issuance"}
 
 When an Endorsement is presented to a Moderator, the Moderator learns
-whether or not the Endorsement is part of a set of Anchor it trusts. The
-presentation must not be linkable to a specific Anchor or other presentations of
-that same Endorsement.
+whether or not the Endorsement originates from the set of Anchors it trusts. The
+presentation must not be reveal the Anchor the Client has been endorsed by,
+and must not be linkable to other presentations of made using that same
+Endorsement.
 
 ### Credential Presentation and updates
 
@@ -341,7 +342,7 @@ CredentialFinalization         |                       |
 
 When a Moderator credential is presented to a Site, the Site learns
 whether or not it satisfies a Site specific policy. The presentation
-must not be linkable to past updates.
+must not be linkable to past updates, or to the credential issuance.
 
 Credential updates must demonstrate that they are applied to the same
 credential as was initially presented. This prevents attacks where an

--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -27,6 +27,14 @@ author:
     fullname: Samuel Schlesinger
     organization: Google LLC
     email: sgschlesinger@gmail.com
+ -
+    fullname: Dennis Jackson
+    organization: Mozilla
+    email: ietf@dennis-jackson.uk
+ -
+    fullname: Thibault Meunier
+    organization: Cloudflare
+    email: ot-ietf@thibault.uk
 
 normative:
 
@@ -49,13 +57,13 @@ TODO Abstract
 # Introduction
 
 Moderation of unLinkable Endorsements (MoLE) is an architecture in which
-Origins make authorization decisions from unlinkable, issuer-hiding credential
+Sites make authorization decisions from unlinkable, issuer-hiding credential
 presentations derived from scarce signals.
 
-Users often encounter friction when an Origin has little prior context about
+Users often encounter friction when an Site has little prior context about
 them: for example, when they arrive with no cookies, use a VPN, enable
 privacy-preserving browser settings, or delegate browsing to a software agent.
-In those cases, the Origin may present a CAPTCHA, use fingerprinting, reject the
+In those cases, the Site may present a CAPTCHA, use fingerprinting, reject the
 request, or return a degraded experience. These mechanisms add friction,
 collect more information about users, or both. They affect users with strong
 privacy preferences and users with accessibility needs. {{INTERNET-END-USER}}
@@ -63,34 +71,34 @@ directs the IETF to consider the interests of end users;
 {{PERVASIVE-MONITORING}} treats pervasive monitoring as an attack.
 
 MoLE aims to reduce this friction, whilst maintaining the privacy of users, by
-enabling new information flows between Origins subject to cryptographically
+enabling new information flows between Sites subject to cryptographically
 enforced limits.
 
-Some Origins have access to relatively rich context about a user, e.g. because
+Some Sites have access to relatively rich context about a user, e.g. because
 the user maintains an account, made a payment or provided some other scare
-signal to the Origin. MoLE enables such Origins to act as Anchors which issue
+signal to the Site. MoLE enables such Sites to act as Anchors which issue
 Endorsements to users, suitable for bootstrapping trust in other contexts.
 
-MoLE enables multiple Origins to share an access policy through a
+MoLE enables multiple Sites to share an access policy through a
 Moderator. The Moderator holds a list of trusted Anchors, and can use the Anchor's
 Endorsements to issue Credentials to Users which are suitable for use on any of
-it's associated Origins. The Moderator can adjust their confidence in the
+it's associated Sites. The Moderator can adjust their confidence in the
 credentials presented by a user over time. This allows the Moderator to reduce
 friction for honest users and increase friction for users which are judged to be
 misbehaving (e.g. spamming, credential stuffing, etc).
 
 MoLE
-delivers this functionality whilst providing strong privacy protections for users. Origins and Moderators cannot
+delivers this functionality whilst providing strong privacy protections for users. Sites and Moderators cannot
 learn which Anchors a user has access to, only that it holds at least one
 suitable Endorsement from the Moderator's trusted list (Anchor Blindness).
-Further, even if Origins, Moderators and Anchors all collude in an attempt to
+Further, even if Sites, Moderators and Anchors all collude in an attempt to
 violate User privacy, the user's presentation of their credentials and
 endorsements cannot be linked across different contexts (Unlinkability).
 
 MoLE is inspired by the Privacy Pass architecture {{RFC9576}}, but differs in
 a number of aspects.
 
-Firstly, MoLE provides greater utility to Origins by enabling Moderators to
+Firstly, MoLE provides greater utility to Sites by enabling Moderators to
 dynamically adjust access in response to how a credential is used. Privacy Pass
 enforces a flat rate limit based on access to an underlying credential which
 cannot be curtailed even if usage is obviously abusive. This leads to
@@ -98,7 +106,7 @@ fundamentally different information flows, privacy analysis and cryptographic
 techniques.
 
 Secondly, MoLE targets a deployment in an open ecosystem where multiple Anchors,
-Moderators and Origins coexist with different policies. This openness, necessary
+Moderators and Sites coexist with different policies. This openness, necessary
 for deployment in contexts like the Web, requires stronger privacy properties
 than are delivered by Privacy Pass. For example, MoLE cannot rely on
 non-collusion assumptions between Issuer and Attester as is required in Privacy
@@ -123,39 +131,39 @@ most strongly load-bearing for the second.
 
 ## Reduced-Friction Challenges {#uc-friction}
 
-A user visits an Origin for the first time, with no cookies, possibly through a
-VPN or shared NAT that obscures the network-layer identifier. The Origin has no
+A user visits an Site for the first time, with no cookies, possibly through a
+VPN or shared NAT that obscures the network-layer identifier. The Site has no
 per-user history and limited reputational signal from the network path. The
-user is the party who bears the cost of whatever the Origin then chooses ---
+user is the party who bears the cost of whatever the Site then chooses ---
 repeated CAPTCHAs, silent rejection, or a degraded experience --- with
 disproportionate cost to users on privacy-preserving network paths and to users
 with accessibility needs.
 
 In this use case, the Client presents a Moderator credential whose underlying
 Anchor credential attests to a scarce property accepted under the Moderator's
-policy. The Origin combines this signal with its existing inputs to decide
+policy. The Site combines this signal with its existing inputs to decide
 whether to admit, challenge, or reject the request. A Moderator credential is
 one input among several; it does not entitle the Client to admission.
 
 Two consequences shape the design. First, the Client presents a Moderator
-credential to the Origin in a single request/response exchange; acquisition of
+credential to the Site in a single request/response exchange; acquisition of
 Anchor and Moderator credentials happens off this path. Second, the design must
 admit user agents partially or wholly automated on behalf of the user; see
 {{uc-agents}}.
 
 ## User Agents Acting Under Delegation {#uc-agents}
 
-A user delegates some of their interaction with an Origin to an automated agent
+A user delegates some of their interaction with an Site to an automated agent
 running in, or alongside, their browser. Such an agent is a user agent: it acts
 under delegation from a user who could otherwise have driven the browser
-themselves. Origins that lack a richer signal commonly treat the appearance of
+themselves. Sites that lack a richer signal commonly treat the appearance of
 automation as grounds for friction or denial of service. This blocks delegated
 browsing as a side effect of resisting unwanted automation.
 
 In this use case, the user agent presents a Moderator credential on the user's
-behalf. The Origin admits the request based on the user's standing without the
+behalf. The Site admits the request based on the user's standing without the
 user agent surfacing a stable identity or correlatable state. From the
-credential alone, the Moderator and the Origin cannot distinguish presentations
+credential alone, the Moderator and the Site cannot distinguish presentations
 driven by the agent from presentations driven by the user directly.
 Distinguishability via request content, timing, or rate is the responsibility
 of the user agent and is not addressed by the credential.
@@ -163,7 +171,7 @@ of the user agent and is not addressed by the credential.
 When delegated agent behaviour violates a Moderator's policy, the Moderator may
 update state bound to the user's Moderator credential. This is a deliberate
 design choice: the user bears the policy consequence of how they have chosen to
-delegate, but does so via a credential unlinkable to the Origin, not via
+delegate, but does so via a credential unlinkable to the Site, not via
 per-user reputation visible to it. The scope of that state, and the requirement
 that Moderator state updates not leak information equivalent to per-user state
 queries, are addressed in {{privacy-properties}}.
@@ -184,14 +192,14 @@ agents is therefore drawn by Anchors and Moderators.
 
 ## Private Access Control {#uc-access}
 
-A user visits an Origin repeatedly, without persistent cookies, expecting that
-successive visits are not linkable to one another. The Origin gates some
+A user visits an Site repeatedly, without persistent cookies, expecting that
+successive visits are not linkable to one another. The Site gates some
 functionality on a non-public criterion such as a paid subscription, group
 membership, or a per-period quota of allowed operations.
 
 In this use case, the Anchor's attestation conveys eligibility under such a
 criterion, and the Moderator translates that eligibility into a credential
-under a policy that may include rate or quota state. Against the Origin alone,
+under a policy that may include rate or quota state. Against the Site alone,
 successive presentations are unlinkable to each other and to issuance. The
 Moderator necessarily observes issuance; cross-presentation linkage at the
 Moderator is bounded to the granularity of the rate or quota state the
@@ -212,9 +220,9 @@ architecture document but may be included in companion documents.
 The following terms are used throughout this document:
 
 **Client:**
-: An entity that seeks access to resources held by an Origin.
+: An entity that seeks access to resources held by an Site.
 
-**Origin:**
+**Site:**
 : An entity that consumes presentations from Clients and uses them to make
   authorization decisions.
 
@@ -236,14 +244,14 @@ The following terms are used throughout this document:
   specified attributes.
 
 **Policy:**
-: Rules used by a Moderator or Origin to evaluate presentations.
+: Rules used by a Moderator or Site to evaluate presentations.
 
 # Architecture {#architecture}
 
 ## Overview
 
 The Client obtains a credential from an Anchor, presents it to a Moderator, and
-uses the resulting Moderator credential when sending requests to an Origin.
+uses the resulting Moderator credential when sending requests to an Site.
 
 TODO: should tghis be three diagarms so we can detail things better? Should it be
 like reverse flow privacy pass and then map roles (anchor, moderator) onto flows?
@@ -350,7 +358,7 @@ and cryptographic instantiation are specified in companion documents.
 
 MoLE constructions provide three privacy properties.
 
-1. *Moderator-credential unlinkability.* An Origin cannot link two valid
+1. *Moderator-credential unlinkability.* A Site cannot link two valid
    Moderator-credential presentations to the same Client from the presentation
    alone.
 
@@ -358,15 +366,13 @@ MoLE constructions provide three privacy properties.
    underlying Anchor is in the Moderator's accepted Anchor set, but not which
    Anchor issued the Anchor credential.
 
-3. *Anchor-credential post-issuance unlinkability.* A Moderator cannot link an
-   Anchor-credential presentation to its issuance transcript.
+3. *Anchor-endorsement post-issuance unlinkability.* A Moderator cannot link an
+   Anchor-endorsement presentation to its issuance transcript. Constructions are
+   expected to preserve this property against adversaries that record issuance
+   traffic and later gain access to quantum computation.
 
-Constructions are expected to preserve these properties against
-adversaries that record issuance traffic and later gain access to
-quantum computation.
-
-A successful presentation tells the Origin that the Client holds a Moderator
-credential satisfying the Origin's policy. It does not reveal the Client's
+A successful presentation tells the Site that the Client holds a Moderator
+credential satisfying the Site's policy. It does not reveal the Client's
 identity, the underlying Anchor, or a score assigned by the Moderator.
 
 ## Threat Model
@@ -375,7 +381,7 @@ The properties above are cryptographic properties of the protocol transcript.
 They do not hide information available outside the transcript, such as network
 metadata, request contents, timing, or user-agent fingerprinting.
 
-Collusion changes the privacy properties. For example, an Origin and Moderator
+Collusion changes the privacy properties. For example, an Site and Moderator
 that share request timing, network metadata, and validation logs may be able to
 link presentations even when the credential presentation itself is unlinkable.
 Deployment sections describe which entities need to be separated for a given
@@ -395,7 +401,7 @@ that partition Clients into small sets.
 ## State
 
 Moderator credentials can carry policy state, such as quota or revocation state.
-State updates must not give an Origin or Moderator a stable handle that links
+State updates must not give an Site or Moderator a stable handle that links
 future presentations by the same Client.
 
 The details are construction-specific. Companion documents need to specify what
@@ -406,12 +412,12 @@ update.
 
 MoLE does not address all channels that can identify Clients. Relevant channels
 include network metadata between Client and Anchor, Client and Moderator, and
-Client and Origin; presentation timing; request contents; accepted-set churn;
+Client and Site; presentation timing; request contents; accepted-set churn;
 policy changes; and key rotation.
 
 These channels need deployment-specific mitigations. For example, {{OBLIVIOUS-HTTP}}
 can hide network metadata between the Client and Anchor or
-Moderator. The Client-Origin channel is outside this architecture.
+Moderator. The Client-Site channel is outside this architecture.
 
 # Deployment Considerations
 

--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -247,6 +247,7 @@ uses the resulting Moderator credential when sending requests to an Origin.
 
 TODO: should tghis be three diagarms so we can detail things better? Should it be
 like reverse flow privacy pass and then map roles (anchor, moderator) onto flows?
+What about state, which is a key distinction with PP
 
 ~~~ aasvg
 +--------+             +--------+             +-----------+             +--------+
@@ -272,7 +273,10 @@ CredentialFinalization     |                        |                       |
 ~~~
 {: #fig-mole-architecture title="MoLE Architecture"}
 
-## Protocols
+## Flows
+
+TODO: for each flow, provide a succint description
+Similar to {{RFC9576}}, this section does not dive into context creation
 
 ### Endorsement
 

--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -250,26 +250,26 @@ like reverse flow privacy pass and then map roles (anchor, moderator) onto flows
 What about state, which is a key distinction with PP
 
 ~~~ aasvg
-+--------+             +--------+             +-----------+             +--------+
-| Client |             | Anchor |             | Moderator |             | Origin |
-+---+----+             +---+----+             +-----+-----+             +---+----+
-    |                      |                        |                       |
-    +-- CredentialRequest->|                        |                       |
-    |<-CredentialResponse--+                        |                       |
-CredentialFinalization     |                        |                       |
-    |                      |                        |                       |
-CredentialPresentation     |                        |                       |
-    +----------- CredentialPresentation ----------->|                       |
-    |<----------- CredentialResponse ---------------+                       |
-CredentialFinalization     |                        |                       |
-    |                      |                        |                       |
-CredentialPresentation     |                        |                       |
-    +----------------- Request+CredentialPresentation --------------------->|
-    |                      |                        |<-- ValidateRequest ---+
-    |                      |                        +-- ValidationResult -->|
-    |<---------------- Response+CredentialResponse -------------------------+
-CredentialFinalization     |                        |                       |
-    |                      |                        |                       |
++--------+                 +--------+             +-----------+             +------+
+| Client |                 | Anchor |             | Moderator |             | Site |
++---+----+                 +---+----+             +-----+-----+             +---+--+
+    |                          |                        |                       |
+    +--- EndorsementRequest -->|                        |                       |
+    |<-- EndorsementResponse --+                        |                       |
+EndorsementFinalization        |                        |                       |
+    |                          |                        |                       |
+EndorsementPresentation        |                        |                       |
+    +------- EndorsementToken+CredentialRequest ------->|                       |
+    |<--------------- CredentialResponse ---------------+                       |
+CredentialFinalization         |                        |                       |
+    |                          |                        |                       |
+CredentialPresentation         |                        |                       |
+    +------------------------ Request+CredentialToken ------------------------->|
+    |                          |                        |<-- ValidateRequest ---+
+    |                          |                        +-- ValidationResult -->|
+    |<---------------------- Response+CredentialResponse -----------------------+
+CredentialFinalization         |                        |                       |
+    |                          |                        |                       |
 ~~~
 {: #fig-mole-architecture title="MoLE Architecture"}
 
@@ -280,9 +280,51 @@ Similar to {{RFC9576}}, this section does not dive into context creation
 
 ### Endorsement
 
+~~~ aasvg
++--------+                 +--------+
+| Client |                 | Anchor |
++---+----+                 +---+----+
+    |                          |
+    +--- EndorsementRequest -->|
+    |<-- EndorsementResponse --+
+EndorsementFinalization        |
+    |                          |
+~~~
+{: #fig-mole-architecture-endorsement title="MoLE Endorsement"}
+
 ### Credential Issuance
 
+~~~ aasvg
++--------+                 +--------+             +-----------+
+| Client |                 | Anchor |             | Moderator |
++---+----+                 +---+----+             +-----+-----+
+    |<===== Endorsement ======>|                        |
+    |                          |                        |
+EndorsementPresentation        |                        |
+    +------- EndorsementToken+CredentialRequest ------->|
+    |<--------------- CredentialResponse ---------------+
+CredentialFinalization         |                        |
+    |                          |                        |
+~~~
+{: #fig-mole-architecture-issuance title="MoLE Issuance"}
+
 ### Credential Presentation
+
+~~~ aasvg
++--------+               +-----------+             +------+
+| Client |               | Moderator |             | Site |
++---+----+               +-----+-----+             +---+--+
+    |<====== Endorsement =====>|                       |
+    |                          |                       |
+CredentialPresentation         |                       |
+    +------------- Request+CredentialToken ----------->|
+    |                          |<-- ValidateRequest ---+
+    |                          +-- ValidationResult -->|
+    |<----------- Response+CredentialResponse ---------+
+CredentialFinalization         |                       |
+    |                          |                       |
+~~~
+{: #fig-mole-architecture-presentation title="MoLE Presentation"}
 
 When a Moderator credential is presented to a Origin, the Origin learns
 whether or not it satisfies an Origin specific policy. The presentation

--- a/draft-schlesinger-mole-http-transport.md
+++ b/draft-schlesinger-mole-http-transport.md
@@ -1,0 +1,84 @@
+---
+title: "MoLE Architecture"
+abbrev: "MoLE Architecture"
+category: info
+
+docname: draft-schlesinger-mole-http-transport-latest
+submissiontype: IETF
+number:
+date:
+consensus: true
+v: 3
+keyword:
+ - moderation
+ - endorsement
+ - unlinkability
+ - privacy
+venue:
+#  group: "Anti-Fraud Community Group"
+#  type: "Community Group"
+#  mail: "public-antifraud@w3.org"
+#  arch: "https://lists.w3.org/Archives/Public/public-antifraud/"
+  github: "Moderation-of-unLinkable-Endorsements/architecture-draft"
+  latest: "https://Moderation-of-unLinkable-Endorsements.github.io/architecture-draft/draft-schlesinger-mole-http-transport.html"
+
+author:
+ -
+    fullname: Samuel Schlesinger
+    organization: Google LLC
+    email: sgschlesinger@gmail.com
+
+normative:
+  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
+  RFC9577:
+
+informative:
+
+...
+
+--- abstract
+
+TODO Abstract
+
+
+--- middle
+
+# Introduction
+
+We target browser first. We'll need some HTTP transport. We need to iterate over privacy pass to have
+
+1. issuer discovery. Given both the Anchor and the Moderator both attest and issue, exposing material can be done easily
+2. trasmission of the anchor set (format+serialisation)
+3. errors?
+4. reverse flow. Ideally we define a header here that supports CredentialRequest and CredentialResponse. Either we provice one header with a parameter (think step=client-request, step=anchor-response), or distinct headers all together.
+
+# Overview
+
+~~~ aasvg
++--------+                                     +--------+
+| Client |                                     | Origin |
++---+----+                                     +---+----+
+    |                                              |
+    |<--- WWW-Authenticate: CredentialChallenge ---+
+    |                                              |
+(Run issuance and presentation protocol)           |
+    |                                              |
+    +--- Authorization: token                  --->|
+    |    PrivacyPass-Reverse: CredentialRequest    |
+    |                                              |
+    |<-- PrivacyPass-Reverse: CredentialResponse --+
+    |                                              |
+~~~
+
+
+# IANA Considerations
+
+This document has no IANA actions.
+
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+TODO acknowledge.

--- a/draft-schlesinger-mole-http-transport.md
+++ b/draft-schlesinger-mole-http-transport.md
@@ -29,10 +29,9 @@ author:
     email: ot-ietf@thibault.uk
 
 normative:
-  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
-  RFC9577:
 
 informative:
+  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
 
 ...
 
@@ -50,8 +49,7 @@ We target browser first. We'll need some HTTP transport. We need to iterate over
 1. issuer discovery. Given both the Anchor and the Moderator both attest and issue, exposing material can be done easily
 2. trasmission of the anchor set (format+serialisation)
 3. errors?
-4. reverse flow. Ideally we define a header here that supports CredentialRequest and CredentialResponse. Either we provice one header with a parameter (think step=client-request, step=anchor-response), or distinct headers all together.
-5. header name. we probably won't use reserse flow directly
+4. credential issuance+presentation flow. Ideally we define a header here that supports CredentialRequest and CredentialResponse. Either we provice one header with a parameter (think step=client-request, step=anchor-response), or distinct headers all together. This is similar to waht is done in {{REVERSE-FLOW}}
 
 # Overview
 
@@ -65,12 +63,13 @@ We target browser first. We'll need some HTTP transport. We need to iterate over
 (Run issuance and presentation protocol)           |
     |                                              |
     +--- Authorization: token                  --->|
-    |    PrivacyPass-Reverse: CredentialRequest    |
+    |    Mole-Issuance: CredentialRequest          |
     |                                              |
-    |<-- PrivacyPass-Reverse: CredentialResponse --+
+    |<-------- Mole-Issuance: CredentialResponse --+
     |                                              |
 ~~~
 
+Mole-Issuance is a placeholder header. We might want Mole-Presentation as well.
 
 # IANA Considerations
 

--- a/draft-schlesinger-mole-http-transport.md
+++ b/draft-schlesinger-mole-http-transport.md
@@ -44,10 +44,10 @@ TODO Abstract
 
 # Introduction
 
-We target browser first. We'll need some HTTP transport. We need to iterate over privacy pass to have
+We target browser first. We'll need some HTTP transport. We need to iterate to have
 
-1. issuer discovery. Given both the Anchor and the Moderator both attest and issue, exposing material can be done easily
-2. trasmission of the anchor set (format+serialisation)
+1. discovery. Given both the Anchor and the Moderator both attest and issue, exposing material can be done easily
+2. transmission of the anchor set (format+serialisation)
 3. errors?
 4. credential issuance+presentation flow. Ideally we define a header here that supports CredentialRequest and CredentialResponse. Either we provice one header with a parameter (think step=client-request, step=anchor-response), or distinct headers all together. This is similar to waht is done in {{REVERSE-FLOW}}
 

--- a/draft-schlesinger-mole-http-transport.md
+++ b/draft-schlesinger-mole-http-transport.md
@@ -51,13 +51,14 @@ We target browser first. We'll need some HTTP transport. We need to iterate over
 2. trasmission of the anchor set (format+serialisation)
 3. errors?
 4. reverse flow. Ideally we define a header here that supports CredentialRequest and CredentialResponse. Either we provice one header with a parameter (think step=client-request, step=anchor-response), or distinct headers all together.
+5. header name. we probably won't use reserse flow directly
 
 # Overview
 
 ~~~ aasvg
-+--------+                                     +--------+
-| Client |                                     | Origin |
-+---+----+                                     +---+----+
++--------+                                     +------+
+| Client |                                     | Site |
++---+----+                                     +---+--+
     |                                              |
     |<--- WWW-Authenticate: CredentialChallenge ---+
     |                                              |

--- a/draft-schlesinger-mole-http-transport.md
+++ b/draft-schlesinger-mole-http-transport.md
@@ -24,9 +24,9 @@ venue:
 
 author:
  -
-    fullname: Samuel Schlesinger
-    organization: Google LLC
-    email: sgschlesinger@gmail.com
+    fullname: Thibault Meunier
+    organization: Cloudflare
+    email: ot-ietf@thibault.uk
 
 normative:
   REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -29,11 +29,11 @@ author:
     email: sgschlesinger@gmail.com
 
 normative:
-  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
-  RFC9576:
   TLS13: RFC8446
 
 informative:
+  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
+  RFC9576:
 
 ...
 
@@ -52,7 +52,7 @@ I suspect this is likely to lead to another registry, but maybe not needed.
 We will NOT use the vocabulary from {{RFC9576}} but rather use {{REVERSE-FLOW}} vocabulary
 We indeed need to use credentialRequest/response and distinguish finalisation from presentation.
 
-These are not specific to MoLE, but MoLE must constraint them.
+These are not specific to MoLE, but MoLE must constrain them.
 
 # Conventions and Definitions
 

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -1,0 +1,137 @@
+---
+title: "MoLE Protocols"
+abbrev: "MoLE Protocols"
+category: info
+
+docname: draft-schlesinger-mole-protocols-latest
+submissiontype: IETF
+number:
+date:
+consensus: true
+v: 3
+keyword:
+ - moderation
+ - endorsement
+ - unlinkability
+ - privacy
+venue:
+#  group: "Anti-Fraud Community Group"
+#  type: "Community Group"
+#  mail: "public-antifraud@w3.org"
+#  arch: "https://lists.w3.org/Archives/Public/public-antifraud/"
+  github: "Moderation-of-unLinkable-Endorsements/architecture-draft"
+  latest: "https://Moderation-of-unLinkable-Endorsements.github.io/architecture-draft/draft-schlesinger-mole-protocols.html"
+
+author:
+ -
+    fullname: Samuel Schlesinger
+    organization: Google LLC
+    email: sgschlesinger@gmail.com
+
+normative:
+  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
+  RFC9576:
+  TLS13: RFC8446
+
+informative:
+
+...
+
+--- abstract
+
+TODO Abstract
+
+
+--- middle
+
+# Introduction
+
+In this document, we'll register all the token type that privacy pass is lacking and that we need.
+I suspect this is likely to lead to another registry, but maybe not needed.
+
+We will NOT use the vocabulary from {{RFC9576}} but rather use {{REVERSE-FLOW}} vocabulary
+We indeed need to use credentialRequest/response and distinguish finalisation from presentation.
+
+These are not specific to MoLE, but MoLE must constraint them.
+
+# Conventions and Definitions
+
+{::boilerplate bcp14-tagged}
+
+Unless otherwise specified, this document encodes protocol messages in TLS notation ({{Section 3 of TLS13}}). Moreover, all constants are in network byte order.
+
+# Protocols
+
+Beyond ACT (with some improvement), we'll need to specify the following protocol
+
+## Issuance Protocol for Issuer-unlinkable Privately Verifiable Tokens
+
+Token type `0x0531`
+
+Configuration (these bits will probably differ for MoLE, and we should define the discovery we want)
+
+1. Issuer Request URL <-- issuer name is going to be th erequest URL. Name is a footgun meant for private deployment
+2. Issuer public key
+3. Challenge value
+4. Issuer set <-- magic crypto bits?
+
+This token follws this flow with properties
+
+1. how do we build context to get the endorsement
+2. challenge?
+3. presentation context: does it need to be flexible?
+4. obtention of the issuer set from the origin: what information can the client validate to not reveal themselves
+
+Note: this issuance protocol DOES NOT require a reverse flow, even if in MoLE it will use it to obtain a credential from an endorsement.
+
+Realisation: there is work to do something like https://eprint.iacr.org/2026/870.pdf but without pairing
+
+### Client to Issuer
+
+~~~tls
+struct CredentialRequest {
+  uint16_t token_type = 0x0531; /* Type something(something) */
+  uint8_t truncated_token_key_id; /* Allow for multiple keys per issuer */
+  ...
+}
+~~~
+
+### Issuer to Client
+
+~~~tls
+struct CredentialResponse {
+  opaque response
+}
+~~~
+
+The client finalises the response into a Credential
+
+~~~tls
+struct Credential {
+  uint16_t token_type = 0x0531;
+  opaque cred
+}
+~~~
+
+### Client to Origin
+
+The client knows the set of issuers it needs to present to. It presents the credential to obtain a token
+
+~~~tls
+struct Token {
+  uint16_t token_type = 0x0531;
+  opaque token
+}
+~~~
+
+# IANA Considerations
+
+This document has no IANA actions.
+
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+TODO acknowledge.


### PR DESCRIPTION
This PR aggregates MoLE drafts (architecture, crypto, and HTTP transport) into one repository as discussed in #2.

It also updates the architecture draft to use "Site" terminology, adds co-authors, and describes the three main flows: Endorsement, Credential Issuance, and Credential Presentation/Updates. It also adds early placeholder drafts for protocol token types (as a placeholder crypto API for issuer-hiding) and HTTP transport (placeholder as well).

This is intended to make the document structure and open design questions easier to review and to work on.