### PR TITLE
Fix Credential presentation diagram with "Issuance"

### DIFF
--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -328,7 +328,7 @@ Endorsement.
 +--------+               +-----------+             +------+
 | Client |               | Moderator |             | Site |
 +---+----+               +-----+-----+             +---+--+
-    |<====== Endorsement =====>|                       |
+    |<======= Issuance =======>|                       |
     |                          |                       |
 CredentialPresentation         |                       |
     +------------- Request+CredentialToken ----------->|


### PR DESCRIPTION
Issuance has to happen before presentation. Endorsement is before the issuance itself