### PR TITLE
Mention credential update request for the credential presentation

### DIFF
--- a/draft-schlesinger-mole-architecture.md
+++ b/draft-schlesinger-mole-architecture.md
@@ -314,7 +314,7 @@ flow fails.
 1. The Client obtains an endorsement from one of the trusted anchors and presents
 it along with a credential request to the Moderator. Upon validation of the endorsement presentation, the Moderator returns a
 credential response that the Client finalizes.
-1. The Client provides a credential presentation to the Site. This
+1. The Client provides a credential presentation, which possibly accompies a credential update request, to the Site. This
 may be used to prove that the credential's state is over some threshold, but
 does not reveal the exact value.
 1. The Site issues a request to the Moderator to validate the presentation.


### PR DESCRIPTION
Minor addition to mention that a Client may include a credential update request to the credential presentation to a Site. 
If the moderator credential is represented by a batch of Privacy Pass tokens (or similar one-show tokens), this credential update request could consist of the `IssuanceMessage` for n new tokens.