### PR TITLE
protocols: specify the endorsement and credential protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,9 @@
 Gemfile.lock
 archive.json
 draft-authors-mole-crypto.xml
-draft-schlesinger-mole-architecture.xml
-draft-schlesinger-mole-http-transport.xml
-draft-schlesinger-mole-protocols.xml
+draft-jms-mole-architecture.xml
+draft-jms-mole-http-transport.xml
+draft-jms-mole-protocols.xml
 package-lock.json
 report.xml
 !requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,10 @@
 /versioned/
 Gemfile.lock
 archive.json
+draft-authors-mole-crypto.xml
 draft-schlesinger-mole-architecture.xml
+draft-schlesinger-mole-http-transport.xml
+draft-schlesinger-mole-protocols.xml
 package-lock.json
 report.xml
 !requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,115 +4,18 @@
 
 This is the working area for MoLE IETF drafts. The current items are as follow
 
-1. [Architecture](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-architecture.html) (Datatracker - not published yet)
-2. [HTTP Transport](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-http-transport.html) (Datatracker - not published yet)
-3. [Cryptography integration](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-protocols.html) (Datatracker - not published yet)
+1. [Architecture](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-architecture.html) (Datatracker - not published yet)
+2. [HTTP Transport](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-http-transport.html) (Datatracker - not published yet)
+3. [Protocols](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-protocols.html) (Datatracker - not published yet)
+4. [Cryptography definitions](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-authors-mole-crypto.html) (Datatracker - not published yet)
 
 You can find all drafts and diff on [GitHub Pages](https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/).
 
 The associated mailing list is [mole@ietf.org](https://mailarchive.ietf.org/arch/browse/mole/) ([Subscribe](https://mailman3.ietf.org/mailman3/lists/mole.ietf.org/)).
 
-## Architecture overview
+## Existing implementations
 
-The architecture has three parties:
-
-- **Client**: holds credentials and produces presentations.
-- **Anchor**: issues a publicly verifiable credential attesting to some scarce signal.
-- **Moderator**: holds policy, accepts anchor credentials from a configured set, and issues per-Moderator credentials that gate updates and queries against a site.
-
-### Privacy properties
-
-- Moderator credentials must be **information-theoretically unlinkable**: no party can link two presentations of the same credential chain to each other or to issuance.
-- Anchor credentials must be **computationally unlinkable**, including against quantum-capable adversaries.
-- A presentation against a Moderator's accepted set `A` must be **issuer-hiding**, revealing only that the underlying anchor credential came from some Anchor in `A` and not which one.
-
-### 1. Anchor Issuance
-
-The client obtains a publicly verifiable anchor credential from an Anchor.
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant C as Client
-    participant An as Anchor
-
-    Note over C: ctx := newCtx()
-    Note over C: req := makeReq(ctx, pk_An)
-
-    C->>An: req, blob
-
-    Note over An: authorize(blob)
-    Note over An: (resp, status) := issueAnchor(req, sk_An)
-
-    An->>C: resp, status
-
-    Note over C: anc_cred := finalizeAnchor(ctx, req, resp, anchor_id)
-```
-
-### 2. Transfer (Anchor to Moderator)
-
-The client converts an anchor credential into a moderator credential bound to a specific Moderator's policy.
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant C as Client
-    participant Mod as Moderator
-
-    Mod->>C: A, pk_Mod, pol
-
-    Note over C: ctx := newCtx()
-    Note over C: req := makeReq(ctx, pk_Mod, pol)
-    Note over C: pres := presentAnchor(anc_cred, A)
-
-    C->>Mod: req, pres
-
-    Note over Mod: verifyAnchor(pres, A) ok
-    Note over Mod: cs := initialState()
-    Note over Mod: resp := issueMod(req, sk_Mod, cs)
-
-    Mod->>C: resp, cs
-
-    Note over C: mod_cred := finalizeMod(ctx, pk_Mod, pol, req, resp, cs)
-    Note over C: store(mod_cred, pk_Mod, pol, A)
-```
-
-### 3. Update / Query
-
-The client makes a request against a site, which mediates through a specific Moderator. The Moderator verifies the presentation, updates state, and returns a fresh credential and a status.
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant C as Client
-    participant S as Site
-    participant Mod as Moderator
-
-    S->>C: Moderator identity (pk_Mod, pol)
-
-    Note over C,Mod: if no mod_cred for this Moderator, run Transfer first
-
-    Note over C: ctx := newCtx()
-    Note over C: req := makeReq(ctx, pk_Mod, pol)
-    Note over C: pres := presentMod(mod_cred, pk_Mod, pol)
-
-    C->>S: blob, req, pres
-
-    Note over S: site may withhold parts of blob from Moderator
-    S->>Mod: req, pres, stuff
-
-    Note over Mod: verifyMod(pres, pol, sk_Mod) ok
-    Note over Mod: d := update(stuff)
-    Note over Mod: (resp?, status) := respondMod(req, sk_Mod, d)
-
-    Mod->>S: resp?, status
-
-    Note over S: blob2 := integrate(blob, status)
-
-    S->>C: resp?, blob2
-
-    Note over C: mod_cred := finalizeMod(ctx, pk_Mod, pol, req, resp)
-```
+To be added - name, language, cryptographic suite (if relevant), draft version
 
 ## Contributing
 

--- a/draft-authors-mole-crypto.md
+++ b/draft-authors-mole-crypto.md
@@ -29,6 +29,8 @@ author:
     email: john@example.com
 
 normative:
+  Hash2Curve: RFC9380
+  TLS13: RFC8446
 
 informative:
 

--- a/draft-authors-mole-crypto.md
+++ b/draft-authors-mole-crypto.md
@@ -1,0 +1,114 @@
+---
+title: "MoLE Cryptography"
+abbrev: "MoLE Cryptography"
+category: info
+
+docname: draft-authors-mole-crypto-latest
+submissiontype: IETF
+number:
+date:
+consensus: true
+v: 3
+keyword:
+ - moderation
+ - endorsement
+ - unlinkability
+ - privacy
+venue:
+#  group: "Anti-Fraud Community Group"
+#  type: "Community Group"
+#  mail: "public-antifraud@w3.org"
+#  arch: "https://lists.w3.org/Archives/Public/public-antifraud/"
+  github: "Moderation-of-unLinkable-Endorsements/internet-drafts"
+  latest: "https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-authors-mole-cryptography.html"
+
+author:
+ -
+    fullname: John Doe
+    organization: ACME
+    email: john@example.com
+
+normative:
+
+informative:
+
+...
+
+--- abstract
+
+TODO Abstract
+
+
+--- middle
+
+# Introduction
+
+TODO
+
+# Conventions and Definitions
+
+{::boilerplate bcp14-tagged}
+
+Unless otherwise specified, this document encodes protocol messages in TLS notation ({{Section 3 of TLS13}}). Moreover, all constants are in network byte order.
+
+# Crypto Bits
+
+We define a two round protocol between an Anchor and Client to produce an endorsement, and then a half-round
+Credential generation step presuming the Client knows the Anchors the Issuer accepts. We let hash2curve be the
+Hash2Curve function from {{Hash2Curve}}, and H be hash function whose output length is sufficiently long.
+
+The Endorsement is a structure with m, Y=Hash2Curve(m), Zhat, Xhat and
+private data gamma. The Anchor has a public key X and a private key x,
+and X = xG. The public form of a credential Zhat, Xhat, and a proof
+that Xhat = vG, Zhat = vY. Xhat = gamma X, and the client will prove
+it knows gamma such that Xhat is a power of one of the public keys of
+an Anchor the moderator trusts.
+
+## Issuance Step One: Statement and Commitment
+
+Client randomly selects scalars v and gamma, and sends Yprime = v Y to the anchor.
+
+The Anchor computes Zprime = x Yprime, selects three random scalars aprime, bprime, and tprime.
+It computes a commitment. It then computes T1prime = tprime Yprime, T2Prime = tprime G. It then transmits Zprime, Cprime,
+and T1prime and T2prime to the client.
+
+## Issuance Step Two: Opening and Proof
+
+The client now has to compute some proof elements and send a scalar to the server. The client
+lets Zhat = gamma v^-1 Z. It then picks alpha, a random nonzero scalar, beta, a random scalar,
+epsilon, a random nonzero scalar, and rho, a random scalar. The client computes C = alpha^-1 C' - beta H,
+T1 = epsilon ^ -1 v ^ -1 (T1prime - rho Yprime), T2 = epsilon ^ -1 (T2prime - rho G).
+
+The client now computes e = H(Y, Zhat, T1, T2, C), and sends eprime = epsilon alpha^{-1} gamma e
+to the anchor
+
+The anchor computes rprime = tprime + eprime aprime x and sends back rprime aprime and  bprime.
+
+The client then checks Cprime = aprime G + bprime H, that aprime is invertable, and then computes
+a = alpha ^-1 aprime, b=alpha^-1 bprime - beta, r = epsilon ^ -1 (rprime - rho). The client then
+verifies Xhat, Zhat, m, e, a, b, r  are a valid endorsement as in the section below.
+
+
+## Verifying such an endorsement
+
+A verifier gets Xhat, Zhat, m and e, a, b, r. The verifier computes Y=Hash2Curve(m), and then
+lets T1 = r Y - e a Zhat, T2 = rG - e a Xhat, C = a G + b H. It checks a is not zero and Y is
+not the identity and then checks e = H(Y, Zhat, T1, T2, C).
+
+## Connecting to the issuer
+
+In addition to the above endorsement, the client must prove knowledge of a value gamma such that
+Xhat = gamma Xi for some i, where the Xi is the list of issuers trusted. This is a standard
+OR sigma proof, and we can use sigma stacking to compact the proof.
+
+# IANA Considerations
+
+This document has no IANA actions.
+
+
+--- back
+
+# Acknowledgments
+{:numbered="false"}
+
+TODO acknowledge.

--- a/draft-jms-mole-architecture.md
+++ b/draft-jms-mole-architecture.md
@@ -20,7 +20,7 @@ venue:
 #  mail: "public-antifraud@w3.org"
 #  arch: "https://lists.w3.org/Archives/Public/public-antifraud/"
   github: "Moderation-of-unLinkable-Endorsements/internet-drafts"
-  latest: "https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-architecture.html"
+  latest: "https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-architecture.html"
 
 author:
  -

--- a/draft-jms-mole-architecture.md
+++ b/draft-jms-mole-architecture.md
@@ -3,7 +3,7 @@ title: "Moderation of unLinkable Endorsements (MoLE) Architecture"
 abbrev: "MoLE Architecture"
 category: info
 
-docname: draft-schlesinger-mole-architecture-latest
+docname: draft-jms-mole-architecture-latest
 submissiontype: IETF
 number:
 date:

--- a/draft-jms-mole-http-transport.md
+++ b/draft-jms-mole-http-transport.md
@@ -3,7 +3,7 @@ title: "MoLE HTTP Transport"
 abbrev: "MoLE HTTP Transport"
 category: info
 
-docname: draft-schlesinger-mole-http-transport-latest
+docname: draft-jms-mole-http-transport-latest
 submissiontype: IETF
 number:
 date:

--- a/draft-jms-mole-http-transport.md
+++ b/draft-jms-mole-http-transport.md
@@ -20,9 +20,17 @@ venue:
 #  mail: "public-antifraud@w3.org"
 #  arch: "https://lists.w3.org/Archives/Public/public-antifraud/"
   github: "Moderation-of-unLinkable-Endorsements/internet-drafts"
-  latest: "https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-http-transport.html"
+  latest: "https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-http-transport.html"
 
 author:
+ -
+    fullname: Samuel Schlesinger
+    organization: Google LLC
+    email: sgschlesinger@gmail.com
+ -
+    fullname: Dennis Jackson
+    organization: Mozilla
+    email: ietf@dennis-jackson.uk
  -
     fullname: Thibault Meunier
     organization: Cloudflare
@@ -30,9 +38,9 @@ author:
 
 normative:
   HTTP: RFC9110
-  PROTOCOLS: #I-D.draft-schlesinger-mole-protocols
+  PROTOCOLS: #I-D.draft-jms-mole-protocols
     title: MoLE Protocols
-    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-protocols.html
+    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-protocols.html
   URI: RFC3986
   TLS13: RFC8446
 

--- a/draft-jms-mole-protocols.md
+++ b/draft-jms-mole-protocols.md
@@ -20,9 +20,17 @@ venue:
 #  mail: "public-antifraud@w3.org"
 #  arch: "https://lists.w3.org/Archives/Public/public-antifraud/"
   github: "Moderation-of-unLinkable-Endorsements/internet-drafts"
-  latest: "https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-protocols.html"
+  latest: "https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-protocols.html"
 
 author:
+ -
+    fullname: Samuel Schlesinger
+    organization: Google LLC
+    email: sgschlesinger@gmail.com
+ -
+    fullname: Dennis Jackson
+    organization: Mozilla
+    email: ietf@dennis-jackson.uk
  -
     fullname: Thibault Meunier
     organization: Cloudflare
@@ -32,13 +40,13 @@ normative:
   ACT: I-D.draft-schlesinger-cfrg-act
   ARCHITECTURE: #I-D.draft-schlesinger-mole-architecture
     title: MoLE Architecture
-    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-architecture.html
+    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-architecture.html
   CRYPTO: #I-D.draft-authors-mole-crypto
     title: MoLE Cryptography
     target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-authors-mole-crypto.html
   HTTP-TRANSPORT: #I-D.draft-schlesinger-mole-http-transport
     title: MoLE HTTP Transport
-    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-http-transport.html
+    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-jms-mole-http-transport.html
   LONGFELLOW: I-D.draft-google-cfrg-libzk
   PRIVACYPASS-AUTH: RFC9577
   PRIVACYPASS-BATCHED: I-D.draft-ietf-privacypass-batched-tokens

--- a/draft-jms-mole-protocols.md
+++ b/draft-jms-mole-protocols.md
@@ -3,7 +3,7 @@ title: "MoLE Protocols"
 abbrev: "MoLE Protocols"
 category: info
 
-docname: draft-schlesinger-mole-protocols-latest
+docname: draft-jms-mole-protocols-latest
 submissiontype: IETF
 number:
 date:

--- a/draft-schlesinger-mole-http-transport.md
+++ b/draft-schlesinger-mole-http-transport.md
@@ -30,25 +30,25 @@ author:
 
 normative:
   HTTP: RFC9110
+  PROTOCOLS: I-D.draft-schlesinger-mole-protocols
   URI: RFC3986
   TLS13: RFC8446
 
 informative:
   BASE64: RFC4648
-  PRIVACYPASS_ACT: I-D.draft-schlesinger-privacypass-act
   QUIC: RFC9000
-  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
 
 ...
 
 --- abstract
 
-MoLE targets browser deployments, so Clients, Anchors, Moderators, and Sites
-need an HTTP transport for the protocol flows defined by the architecture.
+MoLE targets browser deployments, so Clients, Anchors, and Moderators need
+an HTTP transport for the protocol flows defined by the architecture.
 
-This document defines HTTP authentication scheme for endorsement, credential
-issuance, and credential presentation. It also defines configuration material
-exposed by Anchors and Moderators.
+This document defines the `Mole` HTTP authentication scheme, which carries
+challenges and presentations for the endorsement and credential flows, and
+the headers used to return credential material. The grant exchanges with
+the Anchor are defined per protocol in {{PROTOCOLS}}.
 
 
 --- middle
@@ -110,50 +110,55 @@ We describe the HTTP authentication method used by a Client that has an
 Endorsement from an Anchor and obtains a Credential from a Moderator.
 
 The `Mole` authentication scheme follows the HTTP authentication framework
-defined in {{HTTP}}. The same scheme is used for three protocol exchanges:
-Client to Anchor endorsement, Client to Moderator credential issuance, and
-Client to Site credential presentation.
+defined in {{HTTP}}. It carries challenges, redemptions, and
+presentations: an Anchor or a Moderator challenges the Client, and the
+Client answers in the `Authorization` header of a request. Only the grant
+exchanges with the Anchor sit outside the scheme. Their carriage is
+defined per endorsement protocol in {{PROTOCOLS}}, for example over HTTP
+POST.
 
 ~~~ aasvg
-+--------+                                     +------+
-| Client |                                     | Site |
-+---+----+                                     +---+--+
-    |                                              |
-    |<--- WWW-Authenticate: CredentialChallenge ---+
-    |                                              |
-(Run issuance and presentation protocol)           |
-    |                                              |
-    +--- Authorization: token                  --->|
-    |    Mole-Issuance: CredentialRequest          |
-    |                                              |
-    |<-------- Mole-Issuance: CredentialResponse --+
-    |                                              |
++--------+                                +-----------+
+| Client |                                | Moderator |
++---+----+                                +-----+-----+
+    |                                           |
+    |<--- WWW-Authenticate: Mole challenge= ----+
+    |                                           |
+(Redeem & Issue, if needed)                     |
+    |                                           |
+    +--- Authorization: Mole presentation= ---->|
+    |                                           |
+    |<----------------------- Mole-Credential --+
+    |                                           |
 ~~~
 
-Mole-Issuance is a placeholder header. We might want Mole-Presentation as well.
+A challenge names a single endorsement or credential type. To offer a
+choice, a server sends multiple `Mole` challenges; the Client picks one it
+supports and MUST ignore challenges whose type it does not recognize.
+
+All base64url values in this document are encoded without padding
+({{BASE64}}).
 
 # Configuration
 
-TODO(thibault)
-1. if protocol section goes into its own draft, this should follow
-2. I suspect we'll use JSON here. If we use key material, I think re-using JWKS is important (even if there are feelings).
-
-Anchors and Moderators publish configuration used by Clients and Sites before
+Anchors and Moderators publish configuration used by Clients before
 running the HTTP authentication flows. Configuration includes endpoint URLs,
 supported protocol types, public key material, and the Anchor set associated
-with each Moderator policy.
+with each Moderator policy. Its contents and format are defined in the Key
+Rotation and Discovery section of {{PROTOCOLS}}.
 
 # Error Handling
 
-Sites can use MoLE as optional authentication. A `200` response MAY include a
-`WWW-Authenticate: Mole` challenge. This tells the Client that a later request
-can include a presentation, for example to get a higher limit or avoid other
-friction.
+Moderators can use MoLE as optional authentication. A `200` response MAY
+include a `WWW-Authenticate: Mole` challenge. This tells the Client that a
+later request can include a presentation, for example to get a higher limit
+or avoid other friction. In such deployments, Clients SHOULD apply the
+greasing rules of {{PROTOCOLS}}.
 
-A `401` response with a `WWW-Authenticate: Mole` challenge means that the Site
-requires MoLE, or another acceptable authentication scheme, before serving the
-resource. A `403` response means that the Site understood the presented MoLE
-material but did not accept it under policy.
+A `401` response with a `WWW-Authenticate: Mole` challenge means that the
+Moderator requires MoLE, or another acceptable authentication scheme,
+before serving the resource. A `403` response means that the Moderator
+understood the presented MoLE material but did not accept it under policy.
 
 ## Endorsement
 
@@ -173,34 +178,17 @@ struct {
   {{BASE64}}.
 
 ~~~
-WWW-Authenticate: Mole challenge="<endorsement-challenge>", realm="anchor"
+WWW-Authenticate: Mole challenge="<endorsement-challenge>",
+                       realm="anchor"
 ~~~
 
-### Client -> Anchor
+### Client <-> Anchor
 
-~~~tls-presentation
-struct {
-  uint16 endorsement_type;
-  opaque request<V>;
-} EndorsementRequest;
-~~~
-
-~~~
-Authorization: Mole endorsement-request="<endorsement-request>"
-~~~
-
-### Anchor -> Client
-
-~~~tls-presentation
-struct {
-  uint16 endorsement_type;
-  opaque response<V>;
-} EndorsementResponse;
-~~~
-
-~~~
-Mole-Endorsement: response="<endorsement-response>"
-~~~
+After receiving a challenge, the Client runs the grant exchanges with the
+Anchor as defined by the endorsement protocol in {{PROTOCOLS}}, for
+example HTTP POST requests such as the ones defined there. The
+`anchor_context` from the challenge is carried into the first request as
+specified by the endorsement type.
 
 ## Issuance
 
@@ -208,14 +196,15 @@ Mole-Endorsement: response="<endorsement-response>"
 
 ~~~tls-presentation
 struct {
-  uint16 endorsement_type; // We always want endorsement type to be present
+  uint16 endorsement_type; // always present, see PROTOCOLS
   opaque challenge<V>;
 } ModeratorChallenge;
 ~~~
 
 * `challenge` which contains a base64url ModeratorChallenge value, encoded per {{BASE64}}
 
-The `challenge` field is interpreted by the selected endorsement type.
+The `challenge` field carries the `Challenge` structure of the named
+endorsement type, defined in {{PROTOCOLS}}.
 
 #### Example refinement
 
@@ -232,31 +221,45 @@ In `MoleModeratorChallenge`, `anchor_set` is opaque. Clients MUST NOT assume
 array semantics unless the endorsement type defines them.
 
 ~~~
-WWW-Authenticate: Mole challenge="<moderator-challenge>", realm="moderator"
+WWW-Authenticate: Mole challenge="<moderator-challenge>",
+                       realm="moderator"
 ~~~
 
 ### Client -> Moderator
 
-MUST be prefixed by `endorsement_type`.
+The Client answers with a `CredentialRequest` ({{PROTOCOLS}}) in the
+`Authorization` header of a request to the Moderator. It carries the
+endorsement redemption, bound to this challenge, together with the
+issuance request.
 
 ~~~
-Authorization: Mole endorsement="..."
+Authorization: Mole credential-request="<credential-request>"
+~~~
+
+### Moderator -> Client
+
+The Moderator returns the `CredentialResponse` ({{PROTOCOLS}}) in the
+`Mole-Credential` response header.
+
+~~~
+Mole-Credential: response="<credential-response>"
 ~~~
 
 ## Presentation
 
-### Site -> Client - Challenge
+### Moderator -> Client - Challenge
 
 ~~~tls-presentation
 struct {
-  uint16 credential_type; // We always want credential type to be present
+  uint16 credential_type; // always present, see PROTOCOLS
   opaque challenge<V>;
 } CredentialChallenge;
 ~~~
 
 * `challenge` which contains a base64url `CredentialChallenge` value, encoded per {{BASE64}}
 
-The `challenge` field is interpreted by the selected credential type.
+The `challenge` field carries the `Challenge` structure of the named
+credential type, defined in {{PROTOCOLS}}.
 
 #### Example refinement
 
@@ -270,91 +273,55 @@ struct {
 
 struct {
   opaque policy_context<V>; // Moderator-generated policy identifier
-  opaque site_context<V>; // Site-chosen binding value, analogous to redemption_context in RFC9577
+  opaque request_context<V>; // binding value, analogous to
+                             // redemption_context in RFC 9577
 } MolePresentationContext;
 ~~~
 
-The `moderator_uri` field contains a URI (defined by {{URI}}).
+The `moderator_uri` field contains a URI (defined by {{URI}}). It names the
+endpoint where the Client runs Redeem & Issue if it holds no Credential.
 
-In `MolePresentationContext`, `policy_context` is generated by the Moderator. It
-identifies the Moderator policy and accepted Anchor set used for this Site.
-Different sites MAY use different policy contexts while sharing the same
-Moderator. The value MUST be non-empty.
+In `MolePresentationContext`, `policy_context` identifies the Moderator
+policy and accepted Anchor set used for this resource. Different resources
+MAY use different policy contexts while sharing the same Moderator. The
+value MUST be non-empty.
 
-The `site_context` field is chosen by the Site. It binds the presentation to a
-request, session, or time window. A non-empty value affects credential caching
-and replay handling.
+The `request_context` field binds the presentation to a request, session,
+or time window. A non-empty value affects credential caching and replay
+handling.
 
 TODO(thibault):
-1. decide exact construction rules for site_context. maybe it should include
-policy_context. These two are separate from now to showcase the site is likely
-to proxy content from the moderator.
+1. decide exact construction rules for request_context. maybe it should
+include policy_context.
 
 ~~~
-WWW-Authenticate: Mole challenge="<credential-challenge>", realm="site"
+WWW-Authenticate: Mole challenge="<credential-challenge>",
+                       realm="moderator"
 ~~~
 
-### Client -> Site - Presentation
+### Client -> Moderator - Presentation
 
 ~~~tls-presentation
 struct {
-  uint16 credential_type; // We always want credential type to be present
+  uint16 credential_type; // always present, see PROTOCOLS
   opaque presentation_and_update<V>;
 } CredentialPresentation;
 ~~~
 
-The `presentation_and_update` field is interpreted by the selected credential
-type.
-
-#### Example refinement
-
-The following structure is an example refinement of `CredentialPresentation`.
-
-~~~tls-presentation
-struct {
-  opaque presentation_context<V>;
-  opaque presentation_proof[Npp];
-  opaque update_request[Nur];
-} MolePresentationAndUpdate;
-~~~
-
-TODO(thibault):
-1. decide exact construction rules for `presentation_and_update`.
+The `presentation_and_update` field carries the `PresentationAndUpdate`
+structure of the named credential type, defined in {{PROTOCOLS}}.
 
 ~~~
 Authorization: Mole presentation="<credential-presentation>"
 ~~~
 
-For Credential types that require private verification, the Site MUST validate
-the presentation with the Moderator identified by `moderator_uri` before
-granting access to a protected resource.
+A complete instantiation example is given in the appendix of
+{{PROTOCOLS}}.
 
-The exact validation method is TBD.
-
-TODO(thibault): provide an actual instantiation example.
-
-### Site -> Moderator - Validation
-
-~~~tls-presentation
-struct {
-  uint16 credential_type;
-  opaque presentation_and_update<V>;
-} ValidationRequest;
-~~~
-
-~~~tls-presentation
-struct {
-  uint16 credential_type;
-  uint8 valid;
-  opaque update_response<V>;
-} ValidationResult;
-~~~
-
-### Site -> Client - Update
+### Moderator -> Client - Update
 
 TODO(thibault)
-1. This is the only place where we don't have an established pattern. We need to define a new header. {{REVERSE-FLOW}} uses PrivacyPass-Reverse. Here is a Mole-Update. I'd like something clearer.
-2. Headers do not have a fixed protocol limit, but large values are hard to deploy. Other instantiations may define another method, such as returning a URL that the client can fetch. TBD
+1. Headers do not have a fixed protocol limit, but large values are hard to deploy. Other instantiations may define another method, such as returning a URL that the client can fetch. TBD
 
 ~~~tls-presentation
 struct {
@@ -367,56 +334,54 @@ struct {
 } OptionalCredentialUpdate;
 ~~~
 
-The Site MUST send `Mole-Update`. The Site sets the update when the Credential
-remains usable after presentation. The Site marks the update as absent to
-intentionally consume the Credential. Clients MUST follow the Credential type
-semantics for reuse after an omitted update.
+The `update_response` field carries the `Update` structure of the named
+credential type, defined in {{PROTOCOLS}}.
+
+Updates use the same `Mole-Credential` header as issuance: both return
+credential material from the Moderator. The parameter distinguishes them,
+`response` for issuance and `update` after a presentation.
+
+The Moderator MUST send `Mole-Credential` with the `update` parameter
+after a presentation. It sets the update when the Credential remains
+usable after presentation. It marks the update as absent to intentionally
+consume the Credential. Clients MUST follow the Credential type semantics
+for reuse after an omitted update.
 
 * `update` which contains a base64url OptionalCredentialUpdate value, encoded per {{BASE64}}
 
 ~~~
-Mole-Update: update="<optional-credential-update>"
+Mole-Credential: update="<optional-credential-update>"
 ~~~
 
 Each credential type MUST define the challenge fields that partition cached
 Credentials, or state that Credentials of that type are not cacheable.
 
 
-# HTTP protocol (probably its own draft)
-
-In {{http-authentication-scheme}}, we define two protocol registries: endorsement and site.
-
-## Endorsement
-
-0x0001 - Anchor-Hiding endorsement
-
-This is the first protocol
-
-## Credentials
-
-0x0001 - ACT
-
-See {{PRIVACYPASS_ACT}}. Will need to be adapted to be specific here.
-
-0x0002 - ReverseFlow(VOPRF(P384))
-
-Presenting a VOPRF token, with the update being a request for a new VOPRF token.
-
-### Client -> Anchor
-
-### Anchor -> Client
-
 # Security Considerations
+
+All exchanges defined in this document MUST be carried over HTTPS.
+
+TODO. The list to cover:
+
+1. Challenge replay and caching: when a Client may reuse a cached
+   credential against a repeated challenge.
+2. Header size limits and what happens when updates exceed them.
 
 # IANA Considerations
 
 ## Authentication Scheme
 
-We register `Mole` as defined in {{http-authentication-scheme}}
+This document registers the `Mole` authentication scheme, as defined in
+{{http-authentication-scheme}}, in the "HTTP Authentication Schemes"
+registry.
 
-## Endorsement registries
+## HTTP Field Names
 
-## Credential registries
+This document registers the `Mole-Credential` field name in the
+"Hypertext Transfer Protocol (HTTP) Field Name Registry".
+
+Endorsement and credential type values are registered in {{PROTOCOLS}}, not
+in this document.
 
 --- back
 

--- a/draft-schlesinger-mole-http-transport.md
+++ b/draft-schlesinger-mole-http-transport.md
@@ -30,7 +30,9 @@ author:
 
 normative:
   HTTP: RFC9110
-  PROTOCOLS: I-D.draft-schlesinger-mole-protocols
+  PROTOCOLS: #I-D.draft-schlesinger-mole-protocols
+    title: MoLE Protocols
+    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-protocols.html
   URI: RFC3986
   TLS13: RFC8446
 

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -559,8 +559,8 @@ Moderator public key. Anything else partitions Clients and leaks state.
 
 ### Presentation and Update
 
-`Challenge` is empty for this type. Binding comes from the `Token`
-structure below.
+`Challenge` is empty for this type. The challenge octets, and therefore
+`challenge_digest`, are constant for a given Moderator configuration.
 
 ~~~ tls-presentation
 struct {
@@ -574,9 +574,13 @@ struct {
 ~~~
 
 The `token` field carries a `Token` as defined in {{PRIVACYPASS-AUTH}}.
-Challenge binding comes from the `Token` structure itself: its
-`challenge_digest` field MUST equal the digest of the Moderator's
-challenge ({{challenge-binding}}).
+Its `challenge_digest` field is fixed when the token is issued, one
+exchange before it is presented, and MUST equal the Moderator's constant
+`challenge_digest` ({{challenge-binding}}). This binds the token to the
+Moderator, not to the exchange that presents it. Anti-replay therefore
+does not come from challenge binding: it comes from the token being
+single-use. The Moderator MUST reject a token whose nonce it has already
+seen.
 
 If the Moderator's policy allows continued access, it returns an `Update`.
 If not, it returns an empty update and the Client is out of credentials.

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -133,9 +133,6 @@ The value 0x0000 is reserved in both registries and MUST NOT appear on the
 wire. Endorsement type 0x0001 means the Moderator establishes trust in the
 Client on its own, and no Endorsement is redeemed.
 
-TODO: decide whether Moderator trust establishment (0x0001) is allowed in
-production deployments or only for testing.
-
 ## Greasing {#greasing}
 
 In order to prevent Moderators from becoming incompatible with future
@@ -175,6 +172,14 @@ Each protocol in this document states where `challenge_digest` enters its
 messages. A verifier MUST reject a redemption or presentation bound to a
 different challenge. This prevents a message captured in one context from
 being replayed in another.
+
+In the endorsement protocols, the presentation is a proof generated at
+redemption time, and `challenge_digest` is an input to that proof: it
+enters the proof transcript in IHAT and the public inputs in Longfellow.
+A proof produced for one challenge does not verify under another.
+Challenge binding is separate from the nullifier. The nullifier is a PRF
+output over a credential-bound secret and the epoch; it limits a Client
+to one presentation per epoch.
 
 # Endorsement Protocols {#endorsement-protocols}
 
@@ -237,8 +242,8 @@ carried in the `endorsement_presentation` field of a `CredentialRequest`
 
 Endorsement type: 0x0002.
 
-TODO: IHAT is a placeholder name. Ask Watson, who is writing {{CRYPTO}},
-what the scheme is called there and align.
+TODO: IHAT is a placeholder name. Once we have a first version for {{CRYPTO}},
+we would align.
 
 IHAT is a pairing-free, issuer-hiding endorsement scheme over P-256. The
 Anchor blindly signs a Client-chosen nullifier. The Client later proves,
@@ -318,6 +323,10 @@ struct {
 } Presentation;
 ~~~
 
+`Present` MUST bind `challenge_digest` into the proof transcript, and
+`Verify` MUST fail when given any other `challenge_digest`. This is a
+requirement on {{CRYPTO}}.
+
 The Moderator runs `Verify(presentation, keys, challenge_digest)`
 ({{CRYPTO}}), which exposes `nf` and `endorsement_context`, and
 additionally checks that:
@@ -332,12 +341,12 @@ issuance. The Endorsement is spent: redeeming it again MUST fail check 2.
 
 Endorsement type: 0x0003.
 
-Where IHAT requires Anchors to run new cryptography, this protocol reuses
-credentials Clients already hold, such as mdocs. The Client proves in zero
-knowledge, using the scheme of {{LONGFELLOW}}, that it holds a valid
-credential from one of an accepted set of issuers, without revealing which
-issuer or any credential attribute. An experimental circuit is described in
-{{HIDDEN-ISSUER-CIRCUIT}}.
+Where IHAT requires Anchors to run new cryptography, this protocol preserves
+backward compatibility with credentials Clients may hold, such as mdocs.
+The Client proves in zero knowledge, using the scheme of {{LONGFELLOW}}, that it
+holds a valid credential from one of an accepted set of issuers, without
+revealing which issuer or any credential attribute. An experimental circuit is
+described in {{HIDDEN-ISSUER-CIRCUIT}}.
 
 There is no grant exchange in this protocol. The Client obtains its
 credential from the Anchor out of band, through whatever legacy issuance
@@ -377,20 +386,24 @@ struct {
 ~~~
 
 The public inputs to the proof are the accepted issuer set, the epoch, the
-nullifier, and `challenge_digest` ({{challenge-binding}}). The Moderator
+nullifier, and `challenge_digest` ({{challenge-binding}}). A proof is
+valid only for its exact public inputs, so a presentation bound to a
+different challenge fails verification. The Moderator
 verifies the proof using the verifier of {{LONGFELLOW}}, then applies the
 same epoch and nullifier-freshness checks as IHAT redemption.
 
 ### Differences from IHAT
 
-The Anchor does not participate in MoLE and need not know it exists. As a
-consequence, the Anchor cannot limit how many Endorsements a Client
-obtains. Scarcity comes only from the one-nullifier-per-epoch rule.
-Deployments that need Anchor-controlled scarcity should prefer IHAT.
+While Longfellow does not require the Anchor to actively participate in MoLE,
+it is preferred to guarantee and control scarcity. Otherwise, the number of
+Endorsements that can be obtained by a given Client is unbounded.
+Scarcity comes both from the participation of the Anchor, and from the
+one-nullifier-per-epoch rule. Deployments without an aware Anchor remain
+possible, but lose Anchor-controlled scarcity.
 
 The required circuit properties, in particular sound nullifier derivation
 from a credential-bound secret, are stated here as requirements on the
-circuit. {{HIDDEN-ISSUER-CIRCUIT}} is one candidate.
+circuit. {{HIDDEN-ISSUER-CIRCUIT}} is one candidate that could be refined.
 
 # Credential Protocols {#credential-protocols}
 
@@ -569,15 +582,6 @@ If the Moderator's policy allows continued access, it returns an `Update`.
 If not, it returns an empty update and the Client is out of credentials.
 
 ### Limitations
-
-This protocol does not bind the update to the presented credential. Token
-issuance is blind, so a Client holding two tokens can present one and
-direct every update to the other. {{ARCHITECTURE}} requires that updates
-provably apply to the presented credential. This protocol relaxes that
-requirement in exchange for running on deployed Privacy Pass code. The
-consequence is that negative updates (revocation by withholding) only work
-against Clients that hold a single credential, which the Moderator cannot
-verify. See {{security-considerations}}.
 
 TODO: define a device binding mechanism, issuing tokens bound to a Client
 key so that presentation requires proof of possession. This would restore

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -24,178 +24,864 @@ venue:
 
 author:
  -
-    fullname: Samuel Schlesinger
-    organization: Google LLC
-    email: sgschlesinger@gmail.com
+    fullname: Thibault Meunier
+    organization: Cloudflare
+    email: ot-ietf@thibault.uk
 
 normative:
   ACT: I-D.draft-schlesinger-cfrg-act
   ARCHITECTURE: I-D.draft-schlesinger-mole-architecture
   CRYPTO: I-D.draft-authors-mole-crypto
-  HTTP-TRANSPORT: I-D.draft-schlesinger-mole-http
+  HTTP-TRANSPORT: I-D.draft-schlesinger-mole-http-transport
   LONGFELLOW: I-D.draft-google-cfrg-libzk
+  PRIVACYPASS-AUTH: RFC9577
   PRIVACYPASS-BATCHED: I-D.draft-ietf-privacypass-batched-tokens
   PRIVACYPASS-PROTOCOLS: RFC9578
   REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
+  SHA2: RFC6234
+  TLS13: RFC8446
 
 informative:
-  RFC9576:
+  HIDDEN-ISSUER-CIRCUIT:
+    title: "Hidden issuer circuit for longfellow-zk"
+    target: https://github.com/thibmeu/longfellow-zk/blob/hidden-issuer-poc/lib/circuits/mdoc/HIDDEN_ISSUER.md
 
 ...
 
 --- abstract
 
-This document defines realisation of {{ARCHITECTURE}}, with two endorsements and two credentials protocols.
+This document defines protocols that instantiate the MoLE architecture: two
+endorsement protocols, by which a Client proves to a Moderator that it holds
+an Endorsement from a trusted Anchor without revealing which one, and three
+credential protocols, by which a Moderator issues, verifies, and updates
+per-Client state without being able to link presentations. It also
+establishes the registries that identify these protocols.
 
 
 --- middle
 
 # Introduction
 
-In this document, we'll register all the token type that privacy pass is lacking and that we need.
-I suspect this is likely to lead to another registry, but maybe not needed.
+The MoLE architecture {{ARCHITECTURE}} defines three roles. Clients obtain
+Endorsements from Anchors, redeem them at Moderators in exchange for
+Credentials, and present those Credentials to Moderators to access
+resources. The architecture states the required properties of Endorsements
+and Credentials but does not say how to build them. This document does.
 
-We will NOT use the vocabulary from {{RFC9576}} but rather use {{REVERSE-FLOW}} vocabulary
-We indeed need to use credentialRequest/response and distinguish finalisation from presentation.
+TODO: the protocols below reflect our current understanding of how MoLE
+may work, and showcase agility. They are not final. Some may be removed,
+others added.
 
-These are not specific to MoLE, but MoLE must constrain them.
+It defines two endorsement protocols and three credential protocols. Each is
+identified by a type value from a registry established in this document
+({{iana}}). The HTTP carriage of challenges, redemptions, and
+presentations is defined in {{HTTP-TRANSPORT}}. This document defines the
+messages themselves and, for the grant flow, the HTTP exchanges that carry
+them.
 
 # Conventions and Definitions
 
 {::boilerplate bcp14-tagged}
 
-Unless otherwise specified, this document encodes protocol messages in TLS notation ({{Section 3 of TLS13}}). Moreover, all constants are in network byte order.
+Protocol messages are described in TLS presentation language ({{Section 3 of
+TLS13}}). This document also uses the optional-value and variable-size
+vector conventions (`optional<T>`, `<V>`) defined in {{HTTP-TRANSPORT}}.
+All constants are in network byte order.
 
-# Endorsement Protocols
+This document uses the following terms for protocol actions:
 
-Endorsements is defined in {{Section X of ARCHITECTURE}}. It takes part in the
-Endorsement flow and the Redemption+Issue flow. Such a protocol is defined in
-three flows: Client to Anchor, Anchor to Client, Client to Moderator. This
-section present two protocols that achieve this.
+Grant:
+: An Anchor gives a Client an Endorsement.
 
-## Issuer-Hiding Anonyous Token {#ihat}
+Redeem:
+: A Client spends an Endorsement at a Moderator. Each Endorsement can be
+  redeemed once.
 
-Vocabulary
+Issue:
+: A Moderator gives a Client a Credential in return for a redemption.
+
+Present:
+: A Client shows a Credential to a Moderator. Each Credential can be
+  presented once. The update replaces it.
+
+Update:
+: The Moderator's adjustment to a presented Credential, returned in the
+  same exchange.
+
+Finalize:
+: The Client-local step that turns a protocol response into a stored
+  Endorsement or Credential.
+
+# Common Requirements {#common}
+
+## Message Types
+
+Every MoLE protocol message MUST begin with a `uint16` type field:
+`endorsement_type` for messages in the endorsement flow, `credential_type`
+for messages in the credential flow. Values are assigned in the registries
+defined in {{iana}}. A recipient that does not recognize the type MUST
+ignore the message. A Client that receives a challenge with an unknown type
+simply does not respond to it.
+
+The value 0x0000 is reserved in both registries and MUST NOT appear on the
+wire. Endorsement type 0x0001 means the Moderator establishes trust in the
+Client on its own, and no Endorsement is redeemed.
+
+TODO: decide whether Moderator trust establishment (0x0001) is allowed in
+production deployments or only for testing.
+
+## Greasing {#greasing}
+
+In order to prevent Moderators from becoming incompatible with future
+credential types, Clients SHOULD send presentations whose
+`credential_type` is a random value from the reserved greased values
+({{iana-grease}}), with some non-trivial probability. The body of a
+greased presentation is random bytes.
+
+The greased values follow the pattern 0x?A?A, spread uniformly across the
+registry space. Moderators MUST handle them exactly as any other unknown
+type and MUST NOT special-case the reserved list: a Moderator that
+enumerates greased values defeats their purpose and will still receive
+unknown types it did not enumerate.
+
+Additionally, when a credential is not required, Clients SHOULD randomly
+choose not to answer a challenge with some non-trivial probability. This
+helps ensure that Moderators maintain their behavior for handling Clients
+without credentials, rather than relying on a presentation always being
+present.
+
+## Challenge Binding {#challenge-binding}
+
+Every redemption and presentation is bound to the challenge that triggered
+it. The binding value is:
+
+~~~
+challenge_digest = SHA-256(challenge)
+~~~
+
+where `challenge` is the challenge structure in its binary form: the
+octets of its TLS-presentation encoding. When a challenge arrives
+base64url encoded in an HTTP header ({{HTTP-TRANSPORT}}), the Client first
+decodes it, then hashes the resulting octets. The digest is never computed
+over the ASCII form. SHA-256 is defined in {{SHA2}}.
+
+Each protocol in this document states where `challenge_digest` enters its
+messages. A verifier MUST reject a redemption or presentation bound to a
+different challenge. This prevents a message captured in one context from
+being replayed in another.
+
+# Endorsement Protocols {#endorsement-protocols}
+
+An endorsement protocol has two parts. First, the Client runs one or more
+request/response exchanges with an Anchor and finalizes the result into an
+Endorsement. This is the grant. Second, the Client redeems the Endorsement
+at a Moderator, proving it came from an Anchor in the Moderator's accepted
+set without revealing which one. Redemption happens inside the Redeem &
+Issue flow ({{credential-protocols}}).
+
+~~~ aasvg
++--------+                    +--------+
+| Client |                    | Anchor |
++---+----+                    +---+----+
+    |                             |
+    +--- EndorsementRequest ----->|  \
+    |<-- EndorsementResponse -----+  |  one or more
+    |            ...              |  /  exchanges
+Finalize                          |
+    |
+    |                        +-----------+
+    |                        | Moderator |
+    |                        +-----+-----+
+    |                              |
+    |<-------- Challenge ----------+
+    +------- Presentation -------->|
+    |                              |
+~~~
+{: #fig-endorsement-flow title="Endorsement grant and redemption"}
+
+Exchanges with the Anchor are HTTP POST requests. The request body has media
+type `application/mole-endorsement-request` and contains an
+`EndorsementRequest`. The response body has media type
+`application/mole-endorsement-response` and contains an
+`EndorsementResponse`. The endorsement type determines how many exchanges
+are needed and what the `body` field contains at each step.
+
+~~~ tls-presentation
+struct {
+  uint16 endorsement_type;
+  opaque body<V>;
+} EndorsementRequest;
+
+struct {
+  uint16 endorsement_type;
+  opaque body<V>;
+} EndorsementResponse;
+~~~
+
+Every endorsement protocol defines two structures. `Challenge` is the
+type-specific content of the Moderator's challenge, carried in its
+`challenge` field ({{HTTP-TRANSPORT}}). Its content, including any Anchor
+set, is opaque at the transport level. Each endorsement type refines it,
+for example into a list of accepted Anchor keys. `Presentation` is the protocol's
+final output: the message a Client sends to redeem the Endorsement,
+carried in the `endorsement_presentation` field of a `CredentialRequest`
+({{credential-protocols}}).
+
+## Issuer-Hiding Anonymous Token (IHAT) {#ihat}
+
+Endorsement type: 0x0002.
+
+TODO: IHAT is a placeholder name. Ask Watson, who is writing {{CRYPTO}},
+what the scheme is called there and align.
+
+IHAT is a pairing-free, issuer-hiding endorsement scheme over P-256. The
+Anchor blindly signs a Client-chosen nullifier. The Client later proves,
+with a 1-of-n OR proof, that its Endorsement verifies under one of the
+Anchor keys the Moderator accepts. The cryptographic operations, and the
+contents of every message body, are defined in {{CRYPTO}}. Until that
+document is complete, bodies in this section are opaque byte strings
+produced and consumed by the functions named below.
+
+The following primitive types are used in this section:
+
+~~~ tls-presentation
+opaque Scalar[32];  /* big-endian integer mod the group order */
+opaque Point[33];   /* P-256 point, SEC1 compressed */
+~~~
+
+### Configuration
+
+The Client needs, from Anchor configuration ({{key-rotation}}):
 
 Anchor Public Key
-: pkI as defined in {{Section X of CRYPTO}}
+: `pkA`, a `Point`, as generated in {{CRYPTO}}.
 
-Challenge
-: an opaque byte string. Might be provided by {{HTTP-TRANSPORT}}
+Endorsement Context
+: an opaque byte string identifying the current epoch. Endorsements are
+  valid for one epoch, see {{key-rotation}}.
 
-### Client to Anchor
+### Grant
 
-The client creates a context as follow
+The grant takes two exchanges with the Anchor.
 
+In the first exchange, the Client runs `Prepare(pkA,
+endorsement_context)` ({{CRYPTO}}), keeps the returned client state, and
+sends the resulting request as the `body` of an `EndorsementRequest`. The
+Anchor runs `Sign(skA, body)`, keeps its own state for the second
+exchange, and returns the result in an `EndorsementResponse`.
+
+In the second exchange, the Client runs `RequestProof(state, body)` and
+sends the result. The Anchor runs `Prove(state, body)` and returns the
+result.
+
+The Client finalizes with `Finalize(state, body)`, which verifies the
+Anchor's commitment opening and produces an Endorsement. The Endorsement
+contains a nullifier `nf` and the `endorsement_context` it was granted
+under. If finalization fails, the Client MUST discard the session. It MUST
+NOT retry with the same state.
+
+The Anchor learns neither `nf` nor the final Endorsement, so it cannot
+recognize the Endorsement when it is later redeemed.
+
+TODO: the two exchanges must be correlated, since the Anchor holds state
+between them. Either {{CRYPTO}} adds a session identifier to its messages
+or this document mandates connection reuse.
+
+### Redemption
+
+The Moderator's challenge ({{HTTP-TRANSPORT}}) carries the set of Anchor
+keys it accepts:
+
+~~~ tls-presentation
+struct {
+  Point keys<V>;      /* accepted Anchor public keys */
+} Challenge;
 ~~~
-client_context = SetupIHATClient("P256-SHA256", PKI)
+
+The order of `keys` is significant: OR-proof branches are matched to keys
+by position. Moderators MUST present the set in the order published in
+their configuration ({{key-rotation}}).
+
+The Client runs `Present(endorsement, keys, challenge_digest)`
+({{CRYPTO}}), with `challenge_digest` computed as in {{challenge-binding}},
+and sends the result:
+
+~~~ tls-presentation
+struct {
+  opaque bytes<V>;    /* output of Present */
+} Presentation;
 ~~~
 
-"P256-SHA256" corresponds to IHAT(P-256, SHA-256) defined in {{Section X of CRYPTO}}.
+The Moderator runs `Verify(presentation, keys, challenge_digest)`
+({{CRYPTO}}), which exposes `nf` and `endorsement_context`, and
+additionally checks that:
 
-... complete once the crypto is done.
+1. `endorsement_context` names the current epoch, and
+2. `nf` has not been seen before in this epoch.
 
-### Anchor to Client
+If all checks pass, the Moderator records `nf` and proceeds with credential
+issuance. The Endorsement is spent: redeeming it again MUST fail check 2.
 
-Response of the anchor + finalisation, if any
+## Longfellow {#longfellow}
 
-### Client to Moderator
+Endorsement type: 0x0003.
 
-OR proof, possibly interactive
+Where IHAT requires Anchors to run new cryptography, this protocol reuses
+credentials Clients already hold, such as mdocs. The Client proves in zero
+knowledge, using the scheme of {{LONGFELLOW}}, that it holds a valid
+credential from one of an accepted set of issuers, without revealing which
+issuer or any credential attribute. An experimental circuit is described in
+{{HIDDEN-ISSUER-CIRCUIT}}.
 
-## Longfellow
+There is no grant exchange in this protocol. The Client obtains its
+credential from the Anchor out of band, through whatever legacy issuance
+that credential uses. The circuit is likewise distributed out of band and
+identified by its hash.
 
-Builds on legacy credential. On the contrary to {{ihat}}, it favours compatibility with legacy credentials
-over using performant cryptography constructions.
+### Configuration
 
-Fill with https://github.com/thibmeu/longfellow-zk/blob/hidden-issuer-poc/lib/circuits/mdoc/HIDDEN_ISSUER.md
-In short, we need a circuit
+The Client needs, from Moderator configuration ({{key-rotation}}):
 
-### Client to Anchor
+Circuit Identifier
+: `circuit_id`, the SHA-256 hash of the circuit both parties use.
 
-### Anchor to Client
+Accepted Issuer Set
+: the credential-issuer certificates the Moderator accepts, in a fixed
+  published order.
 
-### Client to Moderator
+Epoch
+: the validity window redemptions must fall in.
 
-# Credentials Protocols
+### Redemption
 
-Credential is defined in {{Section X of ARCHITECTURE}}. It takes part in the
-Endorsement flow and the Redemption+Issue flow. Such a protocol is defined in
-four flows between the Client and the Moderator, two for the Issuance, and two for the "Presentation and update". 
-This section present three protocols that achieve this.
+This protocol needs no type-specific challenge content: `Challenge` is
+empty. The accepted issuer set, circuit, and epoch come from configuration.
 
-## ACT {#credential-act}
+The Client evaluates the circuit over its credential to produce a proof and
+a nullifier. The nullifier is derived, inside the circuit, from a
+credential-bound secret and the current epoch, so one credential yields
+exactly one valid nullifier per epoch.
 
-Take the information from draft-schlesinger-privacypass-act
-It is very much an anonymous state machine.
+~~~ tls-presentation
+struct {
+  opaque circuit_id[32];
+  opaque nullifier<V>;
+  opaque proof<V>;
+} Presentation;
+~~~
 
-### Issuance
+The public inputs to the proof are the accepted issuer set, the epoch, the
+nullifier, and `challenge_digest` ({{challenge-binding}}). The Moderator
+verifies the proof using the verifier of {{LONGFELLOW}}, then applies the
+same epoch and nullifier-freshness checks as IHAT redemption.
+
+### Differences from IHAT
+
+The Anchor does not participate in MoLE and need not know it exists. As a
+consequence, the Anchor cannot limit how many Endorsements a Client
+obtains. Scarcity comes only from the one-nullifier-per-epoch rule.
+Deployments that need Anchor-controlled scarcity should prefer IHAT.
+
+The required circuit properties, in particular sound nullifier derivation
+from a credential-bound secret, are stated here as requirements on the
+circuit. {{HIDDEN-ISSUER-CIRCUIT}} is one candidate.
+
+# Credential Protocols {#credential-protocols}
+
+A credential protocol has two parts: Redeem & Issue, in which the Client
+redeems an Endorsement and receives a Credential from the Moderator, and
+presentation, in which the Client shows the Credential and receives an
+update. Presentation and update happen in one exchange, following
+{{REVERSE-FLOW}}.
+
+~~~ aasvg
++--------+                             +-----------+
+| Client |                             | Moderator |
++---+----+                             +-----+-----+
+    |                                        |
+    |<------------ Challenge ----------------+
+    +-- Redemption + CredentialRequest ----->|
+    |<-------- CredentialResponse -----------+
+Finalize                                     |
+    |                                        |
+   ...                                       |
+    |                                        |
+    |<------------ Challenge ----------------+
+    +--- Presentation + UpdateRequest ------>|
+    |<------------ UpdateResponse -----------+
+Finalize                                     |
+    |                                        |
+~~~
+{: #fig-credential-flow title="Redeem & Issue, then presentation and update"}
+
+Both parts ride on HTTP requests to the Moderator, since each is an
+authorization. Redeem & Issue carries a `CredentialRequest` in the
+`Authorization` header and receives the `CredentialResponse` in the
+`Mole-Credential` response header. Presentation uses the same
+authentication scheme, with the update returned in the same
+`Mole-Credential` header under its `update` parameter. Carriage is
+defined in {{HTTP-TRANSPORT}}.
+
+~~~ tls-presentation
+struct {
+  uint16 endorsement_type;
+  opaque endorsement_presentation<V>;
+  uint16 credential_type;
+  opaque issuance_request<V>;
+} CredentialRequest;
+
+struct {
+  uint16 credential_type;
+  opaque issuance_response<V>;
+} CredentialResponse;
+~~~
+
+The `endorsement_presentation` field carries the `Presentation` structure
+of the named endorsement type. With `endorsement_type` 0x0001 it is empty,
+and the Moderator relies on its own trust establishment ({{common}}).
+
+Every credential protocol defines five structures. `Challenge` is the
+type-specific content of the Moderator's challenge, carried in its
+`challenge` field ({{HTTP-TRANSPORT}}). `IssuanceRequest` and
+`IssuanceResponse` fill the `issuance_request` and `issuance_response`
+fields above. `PresentationAndUpdate` is carried in the
+`presentation_and_update` field of a `CredentialPresentation`
+({{HTTP-TRANSPORT}}). `Update` is returned in the `update` parameter of
+the `Mole-Credential` header.
+
+## Anonymous Credit Tokens (ACT) {#credential-act}
+
+Credential type: 0x0001.
+
+An ACT credential {{ACT}} is an anonymous state machine: the Moderator can
+test a predicate against the Credential's hidden state and update that
+state, without learning the state or linking presentations. This is the
+credential protocol that provides every property required by
+{{ARCHITECTURE}}, including that updates provably apply to the credential
+that was presented.
+
+### Configuration
+
+The Moderator publishes its ACT public key and the predicate description
+({{key-rotation}}).
+
+### Redeem & Issue
+
+~~~ tls-presentation
+struct {
+  uint8 truncated_key_id;
+  opaque request<V>;
+} IssuanceRequest;
+
+struct {
+  opaque response<V>;
+} IssuanceResponse;
+~~~
+
+The `request` and `response` fields are defined in {{ACT}}. The Client
+finalizes the response into a Credential with an initial state chosen by
+the Moderator's policy.
 
 ### Presentation and Update
 
-## Privacy Pass with a Reverse Flow
+The Client presents the Credential against the challenged predicate,
+spending it, and in the same message requests the replacement that carries
+the updated state.
 
-Only one bit back and forth, leveraging the tokens defined in {{PRIVACYPASS-PROTOCOLS}}.
+~~~ tls-presentation
+struct {
+  opaque challenge_digest[32];
+  opaque key_id[32];
+  opaque spend_proof<V>;
+} PresentationAndUpdate;
 
-Open question: ensure that the update can only be applied to the issuing state, and not transfered?
+struct {
+  opaque refund<V>;
+} Update;
+~~~
 
-### Issuance
+The `spend_proof` and `refund` fields are defined in {{ACT}}. The
+Moderator verifies the spend proof, learns only the predicate result, and
+returns the refund. The Client finalizes the refund into its new
+Credential. ACT guarantees the refund applies to the state that was
+presented.
 
-Request a privacy pass token. The bits are essentially the same as privacy pass , except that
-they are base64url encoded when passed as an HTTP header like defined in {{HTTP-TRANSPORT}}.
+TODO: the exact mapping between the spend and refund operations of {{ACT}}
+and MoLE's predicate and update is not settled. In particular, `Challenge`
+for this type must express the predicate and the charged amount, and its
+contents are not yet defined.
+
+## Privacy Pass with a Reverse Flow {#credential-reverse}
+
+Credential type: 0x0002.
+
+The Credential is a single privately verifiable Privacy Pass token. Any
+token type registered in the Privacy Pass Token Types registry
+({{PRIVACYPASS-PROTOCOLS}}) can be used. The Moderator's configuration
+names one. The Credential encodes one bit: the Client either holds a valid
+token or it does not. Presentation consumes the token. The update, if
+granted, is a fresh token issued through the reverse flow of
+{{REVERSE-FLOW}}, with the Moderator acting as both initial and reverse
+issuer.
+
+The presented and reissued token MUST use the same token type and the same
+Moderator public key. Anything else partitions Clients and leaks state.
+
+### Redeem & Issue
+
+`IssuanceRequest` is a `TokenRequest` and `IssuanceResponse` is a
+`TokenResponse`, both as defined for the configured token type in
+{{PRIVACYPASS-PROTOCOLS}}. The finalized token is the Credential.
 
 ### Presentation and Update
 
-Using {{REVERSE-FLOW}} architecture. The moderator acts as joint initial and reverse issuer.
-We mandate that the presented and requested token use the same protocol and
-are associated to the same public key. This prevents leakage.
+`Challenge` is empty for this type. Binding comes from the `Token`
+structure below.
 
-### Moderator configuration
+~~~ tls-presentation
+struct {
+  opaque token<V>;
+  opaque token_request<V>;  /* TokenRequest */
+} PresentationAndUpdate;
 
-supported algorithm + public key
+struct {
+  opaque token_response<V>; /* TokenResponse */
+} Update;
+~~~
 
-Open question: how to format this configuration? options are
-1. privacy pass like configuration
-2. a new type of configuration
-3. something closer to JWKS/JWP, not sure what is required there.
+The `token` field carries a `Token` as defined in {{PRIVACYPASS-AUTH}}.
+Challenge binding comes from the `Token` structure itself: its
+`challenge_digest` field MUST equal the digest of the Moderator's
+challenge ({{challenge-binding}}).
 
-## Budget Privacy Pass
+If the Moderator's policy allows continued access, it returns an `Update`.
+If not, it returns an empty update and the Client is out of credentials.
 
-Leverages {{PRIVACYPASS-BATCHED}} along with {{REVERSE-FLOW}}.
-The moderator operates N issuer, each representing a power of 2.
-This is known to the client.
+### Limitations
 
-Note: depending on your deployment constraints and the number of bits
-required in the encoding, {{credential-act}} may be better suited.
+This protocol does not bind the update to the presented credential. Token
+issuance is blind, so a Client holding two tokens can present one and
+direct every update to the other. {{ARCHITECTURE}} requires that updates
+provably apply to the presented credential. This protocol relaxes that
+requirement in exchange for running on deployed Privacy Pass code. The
+consequence is that negative updates (revocation by withholding) only work
+against Clients that hold a single credential, which the Moderator cannot
+verify. See {{security-considerations}}.
 
-### Issuance
+TODO: define a device binding mechanism, issuing tokens bound to a Client
+key so that presentation requires proof of possession. This would restore
+the binding between update and presented credential. Open problem.
 
-The client requests a token from the issuer with the highest value.
+## Budget Privacy Pass {#credential-budget}
+
+Credential type: 0x0003.
+
+The Credential is a balance, represented as Privacy Pass tokens drawn from
+N issuers operated by the same Moderator, where issuer i denominates 2^i
+units. Tokens are issued in batches using {{PRIVACYPASS-BATCHED}}, and any
+token type registered in the Privacy Pass Token Types registry that
+supports batched issuance can be used. The Client presents whatever tokens
+it wants, and the sum of their denominations is the amount spent. The
+Moderator returns change and any policy adjustment as freshly issued
+tokens through the reverse flow, summing to the intended new balance.
+
+A presentation reveals that the Client can spend the presented amount.
+That is the predicate the Moderator evaluates, and it is the same
+disclosure an ACT predicate makes. No additional state leaks beyond it.
+
+### Redeem & Issue
+
+`IssuanceRequest` is a `BatchTokenRequest` and `IssuanceResponse` is a
+`BatchTokenResponse` ({{PRIVACYPASS-BATCHED}}), for tokens summing to the
+initial balance set by the Moderator's policy.
 
 ### Presentation and Update
 
-The client present the token with the higest value, while it requests token for each of the other issuer.
-This include issuer with a higher value tan the one it has, in case of a positive update from the issuer.
-The moderator issues tokens that sum up to the update it wants to provide back to the client.
+The challenge indicates the amount to spend:
 
-### Moderator configuration
+~~~ tls-presentation
+struct {
+  uint64 amount;
+} Challenge;
+~~~
 
-Public key for each issuer, value of the issuer (possiby infered from the order), refund endpoint to exchange multiple
-small tokens against a bigger one.
+The `amount` is an indicator, not a per-Client value. A Moderator MUST
+use the same amount for every Client under a policy: varying it
+partitions Clients. Deployments MAY publish the amount out of band
+instead ({{key-rotation}}), in which case the field repeats the published
+value.
 
-# Security Considerations
+~~~ tls-presentation
+struct {
+  opaque tokens<V>;         /* one or more Tokens */
+  opaque token_request<V>;  /* BatchTokenRequest */
+} PresentationAndUpdate;
 
-# IANA Considerations
+struct {
+  opaque token_response<V>; /* BatchTokenResponse */
+} Update;
+~~~
 
-We create two registries
+Challenge binding comes from each `Token` structure, as in
+{{credential-reverse}}. The Client MAY at any time exchange several small
+tokens for larger ones at the Moderator's refund endpoint.
 
-1. Endorsement protocols
-2. Credentials Protocols
+### When to use it
 
-Initially populated with protocols presented in this draft.
+Balances with many possible values need many tokens and padding traffic to
+avoid leaking through request counts. If the state fits an ACT credential,
+{{credential-act}} is simpler and leaks less. This protocol fits
+deployments that already run Privacy Pass issuers and need only coarse
+balances.
+
+# Key Rotation and Discovery {#key-rotation}
+
+TODO.
+
+Anchors and Moderators each publish a configuration that Clients fetch
+before running any flow. It contains their endpoints, supported endorsement
+and credential types, public keys, and, for Moderators, the accepted Anchor
+set for each policy. The order of the accepted set is normative: IHAT
+OR proofs and Longfellow issuer sets match elements by position, so all
+parties must see the same order.
+
+Endorsements live in epochs. The `endorsement_context` of IHAT and the
+epoch of Longfellow name the epoch an Endorsement is granted in, which is
+also the window the Moderator's nullifier store covers. Epoch length is a
+privacy parameter: short epochs shrink the double-spend store but
+partition Clients into smaller anonymity sets. See {{ARCHITECTURE}} for
+the consistency requirements on configuration. A Moderator that shows
+different configurations to different Clients can partition them.
+
+Open questions:
+
+1. Format: a Privacy Pass style directory, or JWKS. Reusing JWKS matters if
+   deployments want existing key-management tooling, despite feelings.
+2. How and when Anchor and Moderator keys rotate.
+3. Whether messages carry a key identifier, such as a truncated key
+   identifier as in Privacy Pass token requests, or a JWK Thumbprint.
+4. How Clients validate Moderator configuration without revealing
+   themselves, and how consistency is audited.
+
+# Privacy Considerations {#privacy-considerations}
+
+TODO. The list to cover:
+
+1. Anchor set verification: the Client must be able to verify the number
+   of Anchors in an accepted set, and that these Anchors are real rather
+   than fabricated by the Moderator. A set padded with fake Anchors
+   shrinks the effective anonymity set to the Clients of the real ones.
+2. Configuration partitioning: accepted-set contents and order as a
+   fingerprinting vector (with {{ARCHITECTURE}}).
+3. Epoch width versus anonymity set size.
+
+# Security Considerations {#security-considerations}
+
+All exchanges defined in this document and {{HTTP-TRANSPORT}} MUST be
+carried over HTTPS.
+
+TODO. The list to cover:
+
+1. Nullifier store sizing and eviction: the store is per epoch, and a
+   Moderator that evicts early re-admits spent Endorsements.
+2. Anchor key compromise: an attacker with an Anchor key in an accepted set
+   can mint Endorsements freely. Blast radius and rotation response.
+3. Reverse-flow update transfer: the two-credential attack of
+   {{credential-reverse}}, and why single-credential enforcement cannot be
+   verified.
+4. Timing and error side channels during verification, especially
+   distinguishing "bad proof" from "spent nullifier".
+
+# IANA Considerations {#iana}
+
+This document establishes two registries under a new "MoLE" group, both
+with a Specification Required policy.
+
+A registration MUST define the per-type structures its flow requires:
+`Challenge` and `Presentation` for endorsement types
+({{endorsement-protocols}}), and `Challenge`, `IssuanceRequest`,
+`IssuanceResponse`, `PresentationAndUpdate`, and `Update` for credential
+types ({{credential-protocols}}). Every message begins with the registered
+`uint16` type ({{common}}). A registration MUST also state how redemption
+or presentation binds `challenge_digest` ({{challenge-binding}}).
+
+## MoLE Endorsement Types
+
+| Value           | Name                          | Reference      |
+|:----------------|:------------------------------|:---------------|
+| 0x0000          | Reserved                      | this document  |
+| 0x0001          | Moderator trust establishment | {{common}}     |
+| 0x0002          | IHAT                          | {{ihat}}       |
+| 0x0003          | Longfellow                    | {{longfellow}} |
+| 0xFF00 - 0xFFFF | Reserved for testing          | this document  |
+{: #endorsement-types title="MoLE Endorsement Types"}
+
+The registration template contains:
+
+* Value: The two-byte endorsement type.
+* Name: A short name for the protocol.
+* Exchanges: The number of request/response exchanges with the Anchor, or
+  "none" if the grant is out of band.
+* Publicly Verifiable: Whether the Endorsement can be verified without
+  Anchor secret key material.
+* Reference: Where the protocol is defined.
+
+### IHAT {#iana-ihat}
+
+* Value: 0x0002
+* Name: IHAT
+* Exchanges: 2
+* Publicly Verifiable: Yes
+* Reference: {{ihat}}
+
+### Longfellow {#iana-longfellow}
+
+* Value: 0x0003
+* Name: Longfellow
+* Exchanges: none (out of band)
+* Publicly Verifiable: Yes
+* Reference: {{longfellow}}
+
+## MoLE Credential Types
+
+| Value           | Name                       | Reference             |
+|:----------------|:---------------------------|:----------------------|
+| 0x0000          | Reserved                   | this document         |
+| 0x0001          | ACT                        | {{credential-act}}    |
+| 0x0002          | Privacy Pass Reverse Flow  | {{credential-reverse}} |
+| 0x0003          | Budget Privacy Pass        | {{credential-budget}} |
+| 0x0A0A, 0x1A1A, ..., 0xFAFA | Reserved for greasing | {{greasing}} |
+| 0xFF00 - 0xFFFF | Reserved for testing       | this document         |
+{: #credential-types title="MoLE Credential Types"}
+
+The registration template contains:
+
+* Value: The two-byte credential type.
+* Name: A short name for the protocol.
+* Bound Update: Whether updates provably apply to the presented
+  credential.
+* Reference: Where the protocol is defined.
+
+### ACT {#iana-act}
+
+* Value: 0x0001
+* Name: ACT
+* Bound Update: Yes
+* Reference: {{credential-act}}
+
+### Privacy Pass Reverse Flow {#iana-reverse}
+
+* Value: 0x0002
+* Name: Privacy Pass Reverse Flow
+* Bound Update: No
+* Reference: {{credential-reverse}}
+
+### Budget Privacy Pass {#iana-budget}
+
+* Value: 0x0003
+* Name: Budget Privacy Pass
+* Bound Update: No
+* Reference: {{credential-budget}}
+
+### Greased Values {#iana-grease}
+
+* Value: 0x0A0A, 0x1A1A, 0x2A2A, 0x3A3A, 0x4A4A, 0x5A5A, 0x6A6A, 0x7A7A,
+  0x8A8A, 0x9A9A, 0xAAAA, 0xBABA, 0xCACA, 0xDADA, 0xEAEA, 0xFAFA
+* Name: RESERVED
+* Bound Update: N/A
+* Reference: {{greasing}}
+
+These values MUST NOT be assigned. Message bodies carrying them contain
+random bytes ({{greasing}}).
+
+## Media Types
+
+| Media Type                            | Reference                 |
+|:--------------------------------------|:--------------------------|
+| application/mole-endorsement-request  | {{endorsement-protocols}} |
+| application/mole-endorsement-response | {{endorsement-protocols}} |
+{: #media-types-table title="MoLE Media Types"}
+
+TODO: full registration templates, following the Privacy Pass template.
 
 
 --- back
+
+# Example {#example}
+
+A Client requests a resource protected by a Moderator that uses credential
+type 0x0002 (Privacy Pass Reverse Flow) and accepts endorsement type
+0x0002 (IHAT).
+
+~~~ aasvg
++--------+     +--------+     +-----------+
+| Client |     | Anchor |     | Moderator |
++---+----+     +---+----+     +-----+-----+
+    |              |                |
+    +--------------|--- request --->|
+    |<-------------|-- challenge ---+
+    +- exchange 1 >|                |
+    |< response 1 -+                |
+    +- exchange 2 >|                |
+    |< response 2 -+                |
+Finalize           |                |
+    +--------------|--- redeem ---->|
+    |<-------------|--- credential -+
+Finalize           |                |
+    +--------------|--- present --->|
+    |<-------------|- ok + update --+
+    |              |                |
+~~~
+{: #fig-example title="Complete exchange"}
+
+The Moderator challenges the Client:
+
+~~~
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Mole challenge="<credential-challenge>",
+                       realm="moderator"
+~~~
+
+The Client holds no Credential for this Moderator, so it first obtains an
+Endorsement. It runs the two IHAT exchanges against the Anchor:
+
+~~~
+POST /mole/endorse HTTP/1.1
+Host: anchor.example
+Content-Type: application/mole-endorsement-request
+
+EndorsementRequest { 0x0002, Prepare(...) }
+~~~
+
+The Anchor answers each POST with an
+`application/mole-endorsement-response` body, and the Client finalizes the
+Endorsement.
+
+The Client then runs Redeem & Issue. It repeats its request, this time
+carrying a `CredentialRequest` that redeems the Endorsement bound to the
+Moderator's challenge together with a Privacy Pass TokenRequest:
+
+~~~
+GET /resource HTTP/1.1
+Host: moderator.example
+Authorization: Mole credential-request="<credential-request>"
+~~~
+
+The Moderator verifies the redemption, records its nullifier, and returns
+a `CredentialResponse` carrying a TokenResponse in the `Mole-Credential`
+header, alongside its unchanged challenge. The Client finalizes it into a
+token and answers the challenge:
+
+~~~
+GET /resource HTTP/1.1
+Host: moderator.example
+Authorization: Mole presentation="<credential-presentation>"
+~~~
+
+The Moderator verifies the presentation and serves the resource. Its
+response carries a `Mole-Credential` header whose `update` parameter
+holds a fresh token, or an absent update if it chose to consume the
+Credential.
 
 # Acknowledgments
 {:numbered="false"}

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -507,8 +507,10 @@ struct {
 ~~~
 
 The `spend_proof` and `refund` fields are defined in {{ACT}}. The
-Moderator verifies the spend proof, learns only the predicate result, and
-returns the refund. The Client finalizes the refund into its new
+Moderator verifies the spend proof and learns whether the Credential's
+hidden state satisfies the challenged predicate. For range-style
+predicates, this necessarily reveals the public bound being tested, but
+not the hidden state value. The Client finalizes the refund into its new
 Credential. ACT guarantees the refund applies to the state that was
 presented.
 
@@ -516,6 +518,9 @@ TODO: the exact mapping between the spend and refund operations of {{ACT}}
 and MoLE's predicate and update is not settled. In particular, `Challenge`
 for this type must express the predicate and the charged amount, and its
 contents are not yet defined.
+
+The `Challenge` for this type therefore needs to identify the predicate,
+including any public bound, and the update to apply.
 
 ## Privacy Pass with a Reverse Flow {#credential-reverse}
 
@@ -591,9 +596,13 @@ it wants, and the sum of their denominations is the amount spent. The
 Moderator returns change and any policy adjustment as freshly issued
 tokens through the reverse flow, summing to the intended new balance.
 
-A presentation reveals that the Client can spend the presented amount.
-That is the predicate the Moderator evaluates, and it is the same
-disclosure an ACT predicate makes. No additional state leaks beyond it.
+A presentation reveals that the Client can spend the challenged amount. If
+the protocol presents exactly one token for that amount, and balance
+management remains Client-local, this is the same disclosure as an ACT
+predicate over that amount: the Moderator learns the predicate result, not
+the Client's remaining balance. Deployments that allow multiple tokens,
+variable denominations, or observable change shapes need padding or another
+mitigation.
 
 ### Redeem & Issue
 
@@ -700,8 +709,9 @@ TODO. The list to cover:
 
 # IANA Considerations {#iana}
 
-This document establishes two registries under a new "MoLE" group, both
-with a Specification Required policy.
+This document sketches two candidate registries under a future "MoLE"
+group. The values below are candidate values for discussion in this -00
+draft and are not stable assignments.
 
 A registration MUST define the per-type structures its flow requires:
 `Challenge` and `Presentation` for endorsement types
@@ -720,7 +730,7 @@ or presentation binds `challenge_digest` ({{challenge-binding}}).
 | 0x0002          | IHAT                          | {{ihat}}       |
 | 0x0003          | Longfellow                    | {{longfellow}} |
 | 0xFF00 - 0xFFFF | Reserved for testing          | this document  |
-{: #endorsement-types title="MoLE Endorsement Types"}
+{: #endorsement-types title="Candidate MoLE Endorsement Type Values"}
 
 The registration template contains:
 
@@ -731,6 +741,8 @@ The registration template contains:
 * Publicly Verifiable: Whether the Endorsement can be verified without
   Anchor secret key material.
 * Reference: Where the protocol is defined.
+
+The following initial registrations are candidates only.
 
 ### IHAT {#iana-ihat}
 
@@ -758,7 +770,7 @@ The registration template contains:
 | 0x0003          | Budget Privacy Pass        | {{credential-budget}} |
 | 0x0A0A, 0x1A1A, ..., 0xFAFA | Reserved for greasing | {{greasing}} |
 | 0xFF00 - 0xFFFF | Reserved for testing       | this document         |
-{: #credential-types title="MoLE Credential Types"}
+{: #credential-types title="Candidate MoLE Credential Type Values"}
 
 The registration template contains:
 

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -29,18 +29,23 @@ author:
     email: sgschlesinger@gmail.com
 
 normative:
-  TLS13: RFC8446
-  Hash2Curve: RFC9380
+  ACT: I-D.draft-schlesinger-cfrg-act
+  ARCHITECTURE: I-D.draft-schlesinger-mole-architecture
+  CRYPTO: I-D.draft-authors-mole-crypto
+  HTTP-TRANSPORT: I-D.draft-schlesinger-mole-http
+  LONGFELLOW: I-D.draft-google-cfrg-libzk
+  PRIVACYPASS-BATCHED: I-D.draft-ietf-privacypass-batched-tokens
+  PRIVACYPASS-PROTOCOLS: RFC9578
+  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
 
 informative:
-  REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
   RFC9576:
 
 ...
 
 --- abstract
 
-TODO Abstract
+This document defines realisation of {{ARCHITECTURE}}, with two endorsements and two credentials protocols.
 
 
 --- middle
@@ -61,123 +66,133 @@ These are not specific to MoLE, but MoLE must constrain them.
 
 Unless otherwise specified, this document encodes protocol messages in TLS notation ({{Section 3 of TLS13}}). Moreover, all constants are in network byte order.
 
-# Protocols
+# Endorsement Protocols
 
-Beyond ACT (with some improvement), we'll need to specify the following protocol
+Endorsements is defined in {{Section X of ARCHITECTURE}}. It takes part in the
+Endorsement flow and the Redemption+Issue flow. Such a protocol is defined in
+three flows: Client to Anchor, Anchor to Client, Client to Moderator. This
+section present two protocols that achieve this.
 
-## Issuance Protocol for Issuer-unlinkable Privately Verifiable Tokens
+## Issuer-Hiding Anonyous Token {#ihat}
 
-Token type `0x0531`
+Vocabulary
 
-Configuration (these bits will probably differ for MoLE, and we should define the discovery we want)
+Anchor Public Key
+: pkI as defined in {{Section X of CRYPTO}}
 
-1. Issuer Request URL <-- issuer name is going to be th erequest URL. Name is a footgun meant for private deployment
-2. Issuer public key
-3. Challenge value
-4. Issuer set <-- magic crypto bits?
+Challenge
+: an opaque byte string. Might be provided by {{HTTP-TRANSPORT}}
 
-This token follws this flow with properties
+### Client to Anchor
 
-1. how do we build context to get the endorsement
-2. challenge?
-3. presentation context: does it need to be flexible?
-4. obtention of the issuer set from the origin: what information can the client validate to not reveal themselves
+The client creates a context as follow
 
-Note: this issuance protocol DOES NOT require a reverse flow, even if in MoLE it will use it to obtain a credential from an endorsement.
-
-Realisation: there is work to do something like https://eprint.iacr.org/2026/870.pdf but without pairing
-
-### Client to Issuer
-
-~~~tls
-struct CredentialRequest {
-  uint16_t token_type = 0x0531; /* Type something(something) */
-  uint8_t truncated_token_key_id; /* Allow for multiple keys per issuer */
-  ...
-}
+~~~
+client_context = SetupIHATClient("P256-SHA256", PKI)
 ~~~
 
-### Issuer to Client
+"P256-SHA256" corresponds to IHAT(P-256, SHA-256) defined in {{Section X of CRYPTO}}.
 
-~~~tls
-struct CredentialResponse {
-  opaque response
-}
-~~~
+... complete once the crypto is done.
 
-The client finalises the response into a Credential
+### Anchor to Client
 
-~~~tls
-struct Credential {
-  uint16_t token_type = 0x0531;
-  opaque cred
-}
-~~~
+Response of the anchor + finalisation, if any
 
-### Client to Origin
+### Client to Moderator
 
-The client knows the set of issuers it needs to present to. It presents the credential to obtain a token
+OR proof, possibly interactive
 
-~~~tls
-struct Token {
-  uint16_t token_type = 0x0531;
-  opaque token
-}
-~~~
+## Longfellow
 
-# Crypto Bits
+Builds on legacy credential. On the contrary to {{ihat}}, it favours compatibility with legacy credentials
+over using performant cryptography constructions.
 
-We define a two round protocol between an Anchor and Client to produce an endorsement, and then a half-round
-Credential generation step presuming the Client knows the Anchors the Issuer accepts. We let hash2curve be the
-Hash2Curve function from {{Hash2Curve}}, and H be hash function whose output length is sufficiently long.
+Fill with https://github.com/thibmeu/longfellow-zk/blob/hidden-issuer-poc/lib/circuits/mdoc/HIDDEN_ISSUER.md
+In short, we need a circuit
 
-The Endorsement is a structure with m, Y=Hash2Curve(m), Zhat, Xhat and
-private data gamma. The Anchor has a public key X and a private key x,
-and X = xG. The public form of a credential Zhat, Xhat, and a proof
-that Xhat = vG, Zhat = vY. Xhat = gamma X, and the client will prove
-it knows gamma such that Xhat is a power of one of the public keys of
-an Anchor the moderator trusts.
+### Client to Anchor
 
-## Issuance Step One: Statement and Commitment
+### Anchor to Client
 
-Client randomly selects scalars v and gamma, and sends Yprime = v Y to the anchor.
+### Client to Moderator
 
-The Anchor computes Zprime = x Yprime, selects three random scalars aprime, bprime, and tprime.
-It computes a commitment. It then computes T1prime = tprime Yprime, T2Prime = tprime G. It then transmits Zprime, Cprime,
-and T1prime and T2prime to the client.
+# Credentials Protocols
 
-## Issuance Step Two: Opening and Proof
+Credential is defined in {{Section X of ARCHITECTURE}}. It takes part in the
+Endorsement flow and the Redemption+Issue flow. Such a protocol is defined in
+four flows between the Client and the Moderator, two for the Issuance, and two for the "Presentation and update". 
+This section present three protocols that achieve this.
 
-The client now has to compute some proof elements and send a scalar to the server. The client
-lets Zhat = gamma v^-1 Z. It then picks alpha, a random nonzero scalar, beta, a random scalar,
-epsilon, a random nonzero scalar, and rho, a random scalar. The client computes C = alpha^-1 C' - beta H,
-T1 = epsilon ^ -1 v ^ -1 (T1prime - rho Yprime), T2 = epsilon ^ -1 (T2prime - rho G).
+## ACT {#credential-act}
 
-The client now computes e = H(Y, Zhat, T1, T2, C), and sends eprime = epsilon alpha^{-1} gamma e
-to the anchor
+Take the information from draft-schlesinger-privacypass-act
+It is very much an anonymous state machine.
 
-The anchor computes rprime = tprime + eprime aprime x and sends back rprime aprime and  bprime.
+### Issuance
 
-The client then checks Cprime = aprime G + bprime H, that aprime is invertable, and then computes
-a = alpha ^-1 aprime, b=alpha^-1 bprime - beta, r = epsilon ^ -1 (rprime - rho). The client then
-verifies Xhat, Zhat, m, e, a, b, r  are a valid endorsement as in the section below.
+### Presentation and Update
 
+## Privacy Pass with a Reverse Flow
 
-## Verifying such an endorsement
+Only one bit back and forth, leveraging the tokens defined in {{PRIVACYPASS-PROTOCOLS}}.
 
-A verifier gets Xhat, Zhat, m and e, a, b, r. The verifier computes Y=Hash2Curve(m), and then
-lets T1 = r Y - e a Zhat, T2 = rG - e a Xhat, C = a G + b H. It checks a is not zero and Y is
-not the identity and then checks e = H(Y, Zhat, T1, T2, C).
+Open question: ensure that the update can only be applied to the issuing state, and not transfered?
 
-## Connecting to the issuer
+### Issuance
 
-In addition to the above endorsement, the client must prove knowledge of a value gamma such that
-Xhat = gamma Xi for some i, where the Xi is the list of issuers trusted. This is a standard
-OR sigma proof, and we can use sigma stacking to compact the proof.
+Request a privacy pass token. The bits are essentially the same as privacy pass , except that
+they are base64url encoded when passed as an HTTP header like defined in {{HTTP-TRANSPORT}}.
+
+### Presentation and Update
+
+Using {{REVERSE-FLOW}} architecture. The moderator acts as joint initial and reverse issuer.
+We mandate that the presented and requested token use the same protocol and
+are associated to the same public key. This prevents leakage.
+
+### Moderator configuration
+
+supported algorithm + public key
+
+Open question: how to format this configuration? options are
+1. privacy pass like configuration
+2. a new type of configuration
+3. something closer to JWKS/JWP, not sure what is required there.
+
+## Budget Privacy Pass
+
+Leverages {{PRIVACYPASS-BATCHED}} along with {{REVERSE-FLOW}}.
+The moderator operates N issuer, each representing a power of 2.
+This is known to the client.
+
+Note: depending on your deployment constraints and the number of bits
+required in the encoding, {{credential-act}} may be better suited.
+
+### Issuance
+
+The client requests a token from the issuer with the highest value.
+
+### Presentation and Update
+
+The client present the token with the higest value, while it requests token for each of the other issuer.
+This include issuer with a higher value tan the one it has, in case of a positive update from the issuer.
+The moderator issues tokens that sum up to the update it wants to provide back to the client.
+
+### Moderator configuration
+
+Public key for each issuer, value of the issuer (possiby infered from the order), refund endpoint to exchange multiple
+small tokens against a bigger one.
+
+# Security Considerations
 
 # IANA Considerations
 
-This document has no IANA actions.
+We create two registries
+
+1. Endorsement protocols
+2. Credentials Protocols
+
+Initially populated with protocols presented in this draft.
 
 
 --- back

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -30,9 +30,15 @@ author:
 
 normative:
   ACT: I-D.draft-schlesinger-cfrg-act
-  ARCHITECTURE: I-D.draft-schlesinger-mole-architecture
-  CRYPTO: I-D.draft-authors-mole-crypto
-  HTTP-TRANSPORT: I-D.draft-schlesinger-mole-http-transport
+  ARCHITECTURE: #I-D.draft-schlesinger-mole-architecture
+    title: MoLE Architecture
+    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-architecture.html
+  CRYPTO: #I-D.draft-authors-mole-crypto
+    title: MoLE Cryptography
+    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-authors-mole-crypto.html
+  HTTP-TRANSPORT: #I-D.draft-schlesinger-mole-http-transport
+    title: MoLE HTTP Transport
+    target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-schlesinger-mole-http-transport.html
   LONGFELLOW: I-D.draft-google-cfrg-libzk
   PRIVACYPASS-AUTH: RFC9577
   PRIVACYPASS-BATCHED: I-D.draft-ietf-privacypass-batched-tokens

--- a/draft-schlesinger-mole-protocols.md
+++ b/draft-schlesinger-mole-protocols.md
@@ -820,23 +820,23 @@ type 0x0002 (Privacy Pass Reverse Flow) and accepts endorsement type
 0x0002 (IHAT).
 
 ~~~ aasvg
-+--------+     +--------+     +-----------+
-| Client |     | Anchor |     | Moderator |
-+---+----+     +---+----+     +-----+-----+
-    |              |                |
-    +--------------|--- request --->|
-    |<-------------|-- challenge ---+
-    +- exchange 1 >|                |
-    |< response 1 -+                |
-    +- exchange 2 >|                |
-    |< response 2 -+                |
-Finalize           |                |
-    +--------------|--- redeem ---->|
-    |<-------------|--- credential -+
-Finalize           |                |
-    +--------------|--- present --->|
-    |<-------------|- ok + update --+
-    |              |                |
++--------+         +--------+      +-----------+
+| Client |         | Anchor |      | Moderator |
++---+----+         +---+----+      +-----+-----+
+    |                  |                 |
+    +------------------|---- request --->|
+    |<-----------------|--- challenge ---+
+    +--- exchange 1 -->|                 |
+    |<-- response 1 ---+                 |
+    +--- exchange 2 -->|                 |
+    |<-- response 2 ---+                 |
+Finalize               |                 |
+    +------------------|---- redeem ---->|
+    |<-----------------|---- credential -+
+Finalize               |                 |
+    +------------------|---- present --->|
+    |<-----------------|-- ok + update --+
+    |                  |                 |
 ~~~
 {: #fig-example title="Complete exchange"}
 


### PR DESCRIPTION
> [!WARNING]
> This change is rather large, because the drafts were mostly empty. I think having a high level about the compositions, then individual protocols (endorsement/credential) would be useful. If that helps, happy to push this commit as its own branch on the main github repository, so that it is rendered by github actions. The PR is meant to provide a more concrete set of discussion, and text mentions that the set of protocols is subject to change at the time of writting.

Start specifying protocols to give a more concrete hook of MoLE.

This commit adds:
1. One section per protocol with its type value, configuration, messages, and behavior,
2. Two endorsement protocols (IHAT, a placeholder name pending the crypto draft, and Longfellow over legacy credentials),
3. Three credential protocols (ACT, Privacy Pass with a reverse flow, budget Privacy Pass construction).

Design decisions worth knowing about:

- Generic envelopes, per-type structures. Every endorsement type defines `Challenge` and `Presentation`. Every credential type defines `Challenge`, `IssuanceRequest`, `IssuanceResponse`, `PresentationAndUpdate`, and `Update`. The http-transport have been updated accordingly (as that draft defined these names initially).
- Redeem & Issue is an authorization, so it uses the Mole auth scheme like presentation does. `Mole-Credential` is the single response header: `response=` for issuance, `update=` after a presentation. Is this the right move: TBD,
- Anchor interactions are left to the protocols draft, which uses POST,
- Challenge binding is clarified. It hashes the decoded challenge octets, and not the base64url ASCII header,
- Clients grease with reserved `0x?A?A` credential types so Moderators keep handling unknown types and absent presentations,
- Two registries: one for endorsement, one for credentials,
- Remove `Site` from the HTTP transport draft.

Key rotation and discovery, privacy considerations, and security considerations are mostly left as TODO.

There is a full example in the appendix.

The crypto bits that were in the previous protocol draft have been split to a `-crypto` draft.

Note: I still have not added authors beyond myself to the `http-transport` and `-protocols` draft, mostly to request consent. @dennisjackson @SamuelSchlesinger you can just say yes and we'll do that before any publication