### PR TITLE
Update to the protocol draft

### DIFF
--- a/draft-jms-mole-protocols.md
+++ b/draft-jms-mole-protocols.md
@@ -43,9 +43,9 @@ normative:
     title: MoLE Cryptography
     target: https://moderation-of-unlinkable-endorsements.github.io/internet-drafts/draft-authors-mole-crypto.html
   HTTP-TRANSPORT: I-D.draft-jms-mole-http-transport
+  IANA: RFC8126
   LONGFELLOW: I-D.draft-google-cfrg-libzk
   PRIVACYPASS-AUTH: RFC9577
-  PRIVACYPASS-BATCHED: I-D.draft-ietf-privacypass-batched-tokens
   PRIVACYPASS-PROTOCOLS: RFC9578
   REVERSE-FLOW: I-D.draft-meunier-privacypass-reverse-flow
   SHA2: RFC6234
@@ -55,14 +55,13 @@ informative:
   HIDDEN-ISSUER-CIRCUIT:
     title: "Hidden issuer circuit for longfellow-zk"
     target: https://github.com/thibmeu/longfellow-zk/blob/hidden-issuer-poc/lib/circuits/mdoc/HIDDEN_ISSUER.md
-
 ...
 
 --- abstract
 
 This document defines protocols that instantiate the MoLE architecture: two
 endorsement protocols, by which a Client proves to a Moderator that it holds
-an Endorsement from a trusted Anchor without revealing which one, and three
+an Endorsement from a trusted Anchor without revealing which one, and two
 credential protocols, by which a Moderator issues, verifies, and updates
 per-Client state without being able to link presentations. It also
 establishes the registries that identify these protocols.
@@ -82,10 +81,10 @@ TODO: the protocols below reflect our current understanding of how MoLE
 may work, and showcase agility. They are not final. Some may be removed,
 others added.
 
-It defines two endorsement protocols and three credential protocols. Each is
+It defines two endorsement protocols and two credential protocols. Each is
 identified by a type value from a registry established in this document
-({{iana}}). The HTTP carriage of challenges, redemptions, and
-presentations is defined in {{HTTP-TRANSPORT}}. This document defines the
+({{iana}}). The HTTP carriage of challenges, requests, redemptions, and
+presentations is defined by {{HTTP-TRANSPORT}}. This document defines the
 messages themselves and, for the grant flow, the HTTP exchanges that carry
 them.
 
@@ -104,15 +103,17 @@ Grant:
 : An Anchor gives a Client an Endorsement.
 
 Redeem:
-: A Client spends an Endorsement at a Moderator. Each Endorsement can be
-  redeemed once.
+: A Client spends an Endorsement at one logical Moderator. A Client MUST NOT
+  attempt to redeem the same Endorsement at a second Moderator. The Moderator
+  enforces replay protection within its configured replay protection scope.
 
 Issue:
 : A Moderator gives a Client a Credential in return for a redemption.
 
 Present:
 : A Client shows a Credential to a Moderator. Each Credential can be
-  presented once. The update replaces it.
+  presented once within the Moderator's configured replay protection scope. The
+  update replaces it.
 
 Update:
 : The Moderator's adjustment to a presented Credential, returned in the
@@ -126,68 +127,61 @@ Finalize:
 
 ## Message Types
 
-Every MoLE protocol message MUST begin with a `uint16` type field:
-`endorsement_type` for messages in the endorsement flow, `credential_type`
-for messages in the credential flow. Values are assigned in the registries
-defined in {{iana}}. A recipient that does not recognize the type MUST
-ignore the message. A Client that receives a challenge with an unknown type
-simply does not respond to it.
+Every outer MoLE message that selects a protocol carries a `uint16` type field.
+These messages are `EndorsementRequest`, `EndorsementResponse`,
+`CredentialRequest`, `CredentialResponse`, `CredentialPresentation`,
+`CredentialUpdate`, `ModeratorChallenge`, and `CredentialChallenge`. Values are
+assigned in {{iana}}. A Client ignores an unknown Challenge. An unknown request
+or response is rejected. A Moderator treats an unknown optional presentation
+as absent and rejects an unknown required presentation. Challenge wrappers are
+exchanged only between a Moderator and Client. They are never sent to an Anchor.
 
 The value 0x0000 is reserved in both registries and MUST NOT appear on the
-wire. Endorsement type 0x0001 means the Moderator establishes trust in the
-Client on its own, and no Endorsement is redeemed.
+wire. Endorsement type 0x0001 means that no Endorsement is required.
 
 ## Greasing {#greasing}
 
 In order to prevent Moderators from becoming incompatible with future
-credential types, Clients SHOULD send presentations whose
-`credential_type` is a random value from the reserved greased values
-({{iana-grease}}), with some non-trivial probability. The body of a
-greased presentation is random bytes.
+credential types, Clients SHOULD send presentations whose `credential_type` is a
+random value from the reserved greased values ({{iana-grease}}), with some
+non-trivial probability. The body of a greased presentation is random bytes. A
+Moderator handles it as if no Credential were presented.
 
 The greased values follow the pattern 0x?A?A, spread uniformly across the
-registry space. Moderators MUST handle them exactly as any other unknown
-type and MUST NOT special-case the reserved list: a Moderator that
-enumerates greased values defeats their purpose and will still receive
-unknown types it did not enumerate.
+registry space. Moderators MUST handle them exactly as any other unknown type
+and MUST NOT special-case the reserved list. A Moderator that enumerates
+greased values defeats their purpose and will still receive unknown types it
+did not enumerate.
 
 Additionally, when a credential is not required, Clients SHOULD randomly
-choose not to answer a challenge with some non-trivial probability. This
+choose not to send a presentation with some non-trivial probability. This
 helps ensure that Moderators maintain their behavior for handling Clients
 without credentials, rather than relying on a presentation always being
 present.
 
-## Challenge Binding {#challenge-binding}
+## Challenges and Contexts {#challenges-and-contexts}
 
-Every redemption and presentation is bound to the challenge that triggered
-it. The binding value is:
+A Moderator Challenge is a message sent by a Moderator to a Client. It selects
+the operation and carries any type-specific input chosen by the Moderator.
+A Moderator Challenge, or a value derived from it, MUST NOT be sent to an
+Anchor.
 
-~~~
-challenge_digest = SHA-256(challenge)
-~~~
+A Context is a protocol-specific cryptographic input. A protocol defines how
+the Client and Moderator derive the same Context from authenticated
+configuration, the operation, and, when required, the Moderator Challenge. A
+Context can include the complete Moderator Challenge, a digest of it, or
+selected fields. Moderator Challenge and Context are therefore not
+interchangeable terms.
 
-where `challenge` is the challenge structure in its binary form: the
-octets of its TLS-presentation encoding. When a challenge arrives
-base64url encoded in an HTTP header ({{HTTP-TRANSPORT}}), the Client first
-decodes it, then hashes the resulting octets. The digest is never computed
-over the ASCII form. SHA-256 is defined in {{SHA2}}.
-
-Each protocol in this document states where `challenge_digest` enters its
-messages. A verifier MUST reject a redemption or presentation bound to a
-different challenge. This prevents a message captured in one context from
-being replayed in another.
-
-In the endorsement protocols, the presentation is a proof generated at
-redemption time, and `challenge_digest` is an input to that proof: it
-enters the proof transcript in IHAT and the public inputs in Longfellow.
-A proof produced for one challenge does not verify under another.
-Challenge binding is separate from the nullifier. The nullifier is a PRF
-output over a credential-bound secret and the epoch; it limits a Client
-to one presentation per epoch.
+Each credential protocol defines the contents of its type-specific
+`CredentialChallenge` body. Endorsement protocols use the common Challenge in
+{{challenge-binding}}. A Moderator MUST retain enough state to verify that a
+response uses a Challenge it issued and that remains valid.
 
 # Endorsement Protocols {#endorsement-protocols}
 
-An endorsement protocol has two parts. First, the Client runs one or more
+An endorsement protocol has two parts. First, before contacting a Moderator,
+the Client runs one or more
 request/response exchanges with an Anchor and finalizes the result into an
 Endorsement. This is the grant. Second, the Client redeems the Endorsement
 at a Moderator, proving it came from an Anchor in the Moderator's accepted
@@ -209,7 +203,7 @@ Finalize                          |
     |                        +-----+-----+
     |                              |
     |<-------- Challenge ----------+
-    +------- Presentation -------->|
+    +-------- Redemption --------->|
     |                              |
 ~~~
 {: #fig-endorsement-flow title="Endorsement grant and redemption"}
@@ -233,113 +227,169 @@ struct {
 } EndorsementResponse;
 ~~~
 
-Every endorsement protocol defines two structures. `Challenge` is the
-type-specific content of the Moderator's challenge, carried in its
-`challenge` field ({{HTTP-TRANSPORT}}). Its content, including any Anchor
-set, is opaque at the transport level. Each endorsement type refines it,
-for example into a list of accepted Anchor keys. `Presentation` is the protocol's
-final output: the message a Client sends to redeem the Endorsement,
-carried in the `endorsement_presentation` field of a `CredentialRequest`
+The structure fields are:
+
+* `endorsement_type` identifies a registered endorsement protocol.
+* `body` is that protocol's grant message.
+
+The Anchor returns 200 (OK) with the response media type only when it produced
+a complete `EndorsementResponse`. A Client MUST reject a non-success status, an
+unexpected media type, a response whose type differs from its request, trailing
+bytes, or malformed type-specific content. Clients MUST NOT automatically
+redirect a grant POST carrying protocol state. If the second IHAT response is
+lost, the consumed session cannot be replayed. The Client starts a fresh grant
+session.
+
+Every endorsement protocol defines a `Redemption` structure. It is the message
+a Client sends to redeem the Endorsement, carried in the
+`endorsement_presentation` field of a `CredentialRequest`
 ({{credential-protocols}}).
+
+## Redemption Challenge Binding {#challenge-binding}
+
+The type-specific body of `ModeratorChallenge` is:
+
+~~~ tls-presentation
+struct {
+  opaque nonce[32];
+} RedemptionChallenge;
+~~~
+
+The structure fields are:
+
+* `nonce` is an unpredictable value that the Moderator MUST NOT reuse within
+  its configured replay protection scope.
+
+Endorsement protocols compute the following value when creating or verifying
+a redemption:
+
+~~~
+challenge_digest = SHA-256(moderator_challenge)
+~~~
+
+The values are defined as follows:
+
+* `moderator_challenge` is the complete decoded TLS-presentation encoding of
+  the `ModeratorChallenge` sent by the Moderator. It is not required to contain
+  an origin.
+* `challenge_digest` is the 32-octet SHA-256 digest of
+  `moderator_challenge`. It is not computed over a base64url or other textual
+  encoding. SHA-256 is defined in {{SHA2}}.
+
+`challenge_digest` enters the Fiat-Shamir transcript in both IHAT and
+Longfellow, but is not a Longfellow circuit public input. A redemption created
+for one `ModeratorChallenge` does not verify under another.
+
+The `Challenge` algorithm and `ChallengeMessage` in IHAT issuance are defined
+by {{CRYPTO}} and are unrelated to a `ModeratorChallenge`.
+
+## Abstract Endorsement API
+
+Each endorsement protocol defines these abstract operations:
+
+~~~
+RedeemRequest(endorsement, moderator_challenge, configuration)
+  -> redemption | INVALID
+FinalizeRedeem(redemption, moderator_challenge, configuration)
+  -> replay_protection_id | INVALID
+~~~
+
+`RedeemRequest` runs at the Client. `FinalizeRedeem` runs at the Moderator,
+verifies the redemption and Challenge binding, and returns a
+`replay_protection_id` or `INVALID`. Both operations derive
+`challenge_digest` from `moderator_challenge` as specified above. After a
+successful call, the Moderator MUST atomically insert `replay_protection_id`
+in the protocol's configured replay protection scope only if it is absent. If
+it is already present, the Moderator MUST treat the result as `INVALID` and
+MUST NOT process the accompanying `IssuanceRequest`. There is no global replay
+protection service.
+
+## No Endorsement Required {#no-endorsement-required}
+
+Endorsement type 0x0001 indicates that the Moderator does not require an
+Endorsement under its policy. It has no grant. The `endorsement` input and
+`Redemption` are both the distinguished empty value. `RedeemRequest` returns
+that empty value. `FinalizeRedeem` returns `challenge_digest` as its
+`replay_protection_id` when the Moderator's policy permits issuance without an
+Endorsement, and `INVALID` otherwise. This prevents reuse of one Moderator
+Challenge within the configured replay protection scope. This type therefore
+implements the same abstract API as every other endorsement type.
 
 ## Issuer-Hiding Anonymous Token (IHAT) {#ihat}
 
 Endorsement type: 0x0002.
 
-TODO: IHAT is a placeholder name. Once we have a first version for {{CRYPTO}},
-we would align.
-
-IHAT is a pairing-free, issuer-hiding endorsement scheme over P-256. The
-Anchor blindly signs a Client-chosen nullifier. The Client later proves,
-with a 1-of-n OR proof, that its Endorsement verifies under one of the
+This protocol uses the IHAT-TZ variant defined in {{CRYPTO}}. IHAT is a
+pairing-free, issuer-hiding endorsement scheme. The Anchor blindly signs a
+Client-chosen nullifier. The Client later proves,
+with an issuer-hiding proof, that its Endorsement verifies under one of the
 Anchor keys the Moderator accepts. The cryptographic operations, and the
-contents of every message body, are defined in {{CRYPTO}}. Until that
-document is complete, bodies in this section are opaque byte strings
-produced and consumed by the functions named below.
+contents and encodings of every message body, are defined in {{CRYPTO}}.
 
-The following primitive types are used in this section:
+The following primitive types are ciphersuite-dependent:
 
 ~~~ tls-presentation
-opaque Scalar[32];  /* big-endian integer mod the group order */
-opaque Point[33];   /* P-256 point, SEC1 compressed */
+opaque Scalar[Ns];
+opaque Element[Ne];
 ~~~
 
 ### Configuration
 
 The Client needs, from Anchor configuration ({{key-rotation}}):
 
-Anchor Public Key
-: `pkA`, a `Point`, as generated in {{CRYPTO}}.
+IHAT Ciphersuite
+: A ciphersuite identifier defined by {{CRYPTO}}. It determines `Element`,
+  `Scalar`, and all cryptographic encodings.
 
-Endorsement Context
-: an opaque byte string identifying the current epoch. Endorsements are
-  valid for one epoch, see {{key-rotation}}.
+Anchor Public Key
+: `pkA`, an `Element`, as generated in {{CRYPTO}}, with a stable key ID.
+
+Issuance Context
+: `ctx_iss`, the canonical encoding of the issuance epoch. Endorsements are
+  valid for that epoch, see {{key-rotation}}.
+
+Redemption Context
+: `ctx_red`, the ASCII string `"MoLE-IHAT-ctx_red-v1"`, without a terminating
+  NUL byte. This fixed, domain-separated value is the same for all Moderators.
+  This is the cryptographic redemption Context defined by {{CRYPTO}}, not a
+  Moderator Challenge. A specific redemption operation is bound separately by
+  `challenge_digest`.
 
 ### Grant
 
-The grant takes two exchanges with the Anchor.
+The grant takes two HTTP exchanges and three protocol messages. The Anchor
+speaks first, as specified by {{CRYPTO}}:
 
-In the first exchange, the Client runs `Prepare(pkA,
-endorsement_context)` ({{CRYPTO}}), keeps the returned client state, and
-sends the resulting request as the `body` of an `EndorsementRequest`. The
-Anchor runs `Sign(skA, body)`, keeps its own state for the second
-exchange, and returns the result in an `EndorsementResponse`.
+1. The Client sends an `EndorsementRequest` with an empty `body`. The Anchor
+   runs `Commit(skA, ctx_iss)`, stores the returned state under a fresh
+   `session_id`, and returns a `CommitMessage` in the response body.
+2. The Client runs `Challenge(pkA, ctx_iss, ctx_red, commitment)`, stores the
+   returned state, and sends a `ChallengeMessage` containing the returned
+   issuance challenge and opaque `session_id`. The Anchor atomically claims and
+   consumes that identifier before reading the single-use state. Only the
+   instance that wins the claim runs `Respond(skA, state, challenge)` and
+   returns a `ResponseMessage`.
+   Tombstones are retained through session expiry. All later requests for the
+   identifier fail without invoking `Respond`.
+3. The Client runs `Finalize(pkA, state, response)` as specified by {{CRYPTO}}.
+   On failure it MUST discard the session state and MUST NOT retry with that
+   state.
 
-In the second exchange, the Client runs `RequestProof(state, body)` and
-sends the result. The Anchor runs `Prove(state, body)` and returns the
-result.
+`CommitMessage`, `ChallengeMessage`, `ResponseMessage`, `session_id`, and the
+Endorsement encoding are defined by {{CRYPTO}}. The session identifier is only
+transport correlation and is not bound into the Endorsement.
 
-The Client finalizes with `Finalize(state, body)`, which verifies the
-Anchor's commitment opening and produces an Endorsement. The Endorsement
-contains a nullifier `nf` and the `endorsement_context` it was granted
-under. If finalization fails, the Client MUST discard the session. It MUST
-NOT retry with the same state.
-
-The Anchor learns neither `nf` nor the final Endorsement, so it cannot
-recognize the Endorsement when it is later redeemed.
-
-TODO: the two exchanges must be correlated, since the Anchor holds state
-between them. Either {{CRYPTO}} adds a session identifier to its messages
-or this document mandates connection reuse.
+The Anchor learns neither `nf` nor the final Endorsement. Under the statistical
+blindness claim in {{CRYPTO}}, its protocol transcript does not let it
+recognize the Endorsement when it is later redeemed. Timing, network, and
+configuration metadata are outside that claim.
 
 ### Redemption
 
-The Moderator's challenge ({{HTTP-TRANSPORT}}) carries the set of Anchor
-keys it accepts:
-
-~~~ tls-presentation
-struct {
-  Point keys<V>;      /* accepted Anchor public keys */
-} Challenge;
-~~~
-
-The order of `keys` is significant: OR-proof branches are matched to keys
-by position. Moderators MUST present the set in the order published in
-their configuration ({{key-rotation}}).
-
-The Client runs `Present(endorsement, keys, challenge_digest)`
-({{CRYPTO}}), with `challenge_digest` computed as in {{challenge-binding}},
-and sends the result:
-
-~~~ tls-presentation
-struct {
-  opaque bytes<V>;    /* output of Present */
-} Presentation;
-~~~
-
-`Present` MUST bind `challenge_digest` into the proof transcript, and
-`Verify` MUST fail when given any other `challenge_digest`. This is a
-requirement on {{CRYPTO}}.
-
-The Moderator runs `Verify(presentation, keys, challenge_digest)`
-({{CRYPTO}}), which exposes `nf` and `endorsement_context`, and
-additionally checks that:
-
-1. `endorsement_context` names the current epoch, and
-2. `nf` has not been seen before in this epoch.
-
-If all checks pass, the Moderator records `nf` and proceeds with credential
-issuance. The Endorsement is spent: redeeming it again MUST fail check 2.
+> **Editor note.** {{CRYPTO}} does not yet define IHAT redemption. This section
+> is blocked on its exact `Redemption` encoding, `RedeemRequest` and
+> `FinalizeRedeem` algorithms, Context and Challenge binding, replay protection
+> identifier, and security analysis.
 
 ## Longfellow {#longfellow}
 
@@ -354,15 +404,21 @@ described in {{HIDDEN-ISSUER-CIRCUIT}}.
 
 There is no grant exchange in this protocol. The Client obtains its
 credential from the Anchor out of band, through whatever legacy issuance
-that credential uses. The circuit is likewise distributed out of band and
-identified by its hash.
+that credential uses, before contacting a Moderator. A compressed circuit
+artifact containing the two Longfellow circuits is likewise distributed out
+of band and identified by its hash.
 
 ### Configuration
 
 The Client needs, from Moderator configuration ({{key-rotation}}):
 
-Circuit Identifier
-: `circuit_id`, the SHA-256 hash of the circuit both parties use.
+Circuit Artifact Identifier
+: `circuit_artifact_id`, the SHA-256 hash of the compressed circuit artifact
+  both parties use.
+
+Circuit Manifest
+: An out-of-band manifest that names the artifact version, the two circuit
+  identifiers, and all proof parameters needed to interpret and verify it.
 
 Accepted Issuer Set
 : the credential-issuer certificates the Moderator accepts, in a fixed
@@ -371,84 +427,112 @@ Accepted Issuer Set
 Epoch
 : the validity window redemptions must fall in.
 
+Moderator Origin
+: the canonical origin of the Moderator. Its source is trusted configuration.
+  It MUST NOT be derived from a client-controlled HTTP `Host` value.
+
+Verification Time
+: `verification_time`, a Moderator-selected time within the current epoch.
+
 ### Redemption
 
-This protocol needs no type-specific challenge content: `Challenge` is
-empty. The accepted issuer set, circuit, and epoch come from configuration.
+The accepted issuer set, circuit artifact, epoch, Moderator origin, and
+verification time come from authenticated configuration. The selected
+redemption operation supplies the digest of the complete decoded
+`ModeratorChallenge` as `challenge_digest`, as defined in
+{{challenge-binding}}.
 
-The Client evaluates the circuit over its credential to produce a proof and
-a nullifier. The nullifier is derived, inside the circuit, from a
-credential-bound secret and the current epoch, so one credential yields
-exactly one valid nullifier per epoch.
+The Client evaluates the two circuits over its credential to produce a proof
+and a nullifier. The nullifier is derived, inside the circuit, from a
+credential-bound secret, the canonical Moderator origin, and the current
+epoch. One credential therefore yields exactly one valid nullifier per
+Moderator origin and epoch.
 
 ~~~ tls-presentation
 struct {
-  opaque circuit_id[32];
+  opaque circuit_artifact_id[32];
   opaque nullifier<V>;
   opaque proof<V>;
-} Presentation;
+} Redemption;
 ~~~
 
-The public inputs to the proof are the accepted issuer set, the epoch, the
-nullifier, and `challenge_digest` ({{challenge-binding}}). A proof is
-valid only for its exact public inputs, so a presentation bound to a
-different challenge fails verification. The Moderator
-verifies the proof using the verifier of {{LONGFELLOW}}, then applies the
-same epoch and nullifier-freshness checks as IHAT redemption.
+The structure fields are:
+
+* `circuit_artifact_id` is the SHA-256 digest of the configured circuit
+  artifact.
+* `nullifier` is the circuit-produced replay protection identifier.
+* `proof` is the encoded Longfellow proof.
+
+The circuit public inputs are the accepted issuer set, epoch, canonical
+Moderator origin, `verification_time`, and nullifier. The proof establishes
+`validFrom <= verification_time <= validUntil`. `challenge_digest`
+({{challenge-binding}}) is bound into the Longfellow Fiat-Shamir transcript.
+It is not a circuit public input.
+
+Longfellow implements the common API in {{endorsement-protocols}}.
+`RedeemRequest` checks that the artifact and manifest match configuration,
+evaluates the circuits, and returns the encoded `Redemption` above.
+`FinalizeRedeem` checks the artifact identifier, verifies the proof and its
+transcript binding, and checks that the configured epoch and
+`verification_time` remain current. It returns the nullifier as
+`replay_protection_id`, or `INVALID` on any failure. Both operations derive
+`challenge_digest` from `moderator_challenge`. The common caller performs the
+atomic replay protection check.
 
 ### Differences from IHAT
 
-While Longfellow does not require the Anchor to actively participate in MoLE,
-it is preferred to guarantee and control scarcity. Otherwise, the number of
-Endorsements that can be obtained by a given Client is unbounded.
-Scarcity comes both from the participation of the Anchor, and from the
-one-nullifier-per-epoch rule. Deployments without an aware Anchor remain
-possible, but lose Anchor-controlled scarcity.
+Longfellow does not inherently require an Anchor to change its issuance
+protocol. Scarcity then depends on the legacy credential's own issuance limits
+and on whether it contains a credential-bound Client secret suitable for
+nullifier derivation. An Anchor that participates in MoLE can control scarcity
+and arrange for such a secret to be committed during issuance. Some existing
+credential formats may already provide a suitable Client-contributed or
+device-bound secret. The one-nullifier-per-origin-and-epoch rule prevents
+repeat redemption of one credential in that scope. It does not limit how many
+credentials a Client can obtain.
 
-The required circuit properties, in particular sound nullifier derivation
-from a credential-bound secret, are stated here as requirements on the
-circuit. {{HIDDEN-ISSUER-CIRCUIT}} is one candidate that could be refined.
+> **Editor note.** This protocol is blocked on normative circuit definitions,
+> public-input encodings and ordering, transcript binding, artifact lifecycle
+> and size limits, and test vectors.
 
 # Credential Protocols {#credential-protocols}
 
-A credential protocol has two parts: Redeem & Issue, in which the Client
-redeems an Endorsement and receives a Credential from the Moderator, and
-presentation, in which the Client shows the Credential and receives an
-update. Presentation and update happen in one exchange, following
-{{REVERSE-FLOW}}.
+A credential protocol has two parts. In Redeem & Issue, the Client redeems an
+Endorsement and receives a Credential from the Moderator. In Presentation and
+Update, the Client shows the Credential and receives an update in the same
+exchange.
 
 ~~~ aasvg
 +--------+                             +-----------+
 | Client |                             | Moderator |
 +---+----+                             +-----+-----+
     |                                        |
-    |<------------ Challenge ----------------+
-    +-- Redemption + CredentialRequest ----->|
-    |<-------- CredentialResponse -----------+
-Finalize                                     |
+    |<--------- ModeratorChallenge ----------+
+    +--- Redemption + IssuanceRequest ------>|  HTTP request
+    |<---------- IssuanceResponse -----------+
+Finalize                                    |
     |                                        |
    ...                                       |
     |                                        |
-    |<------------ Challenge ----------------+
-    +--- Presentation + UpdateRequest ------>|
-    |<------------ UpdateResponse -----------+
-Finalize                                     |
+    |<-------- CredentialChallenge ----------+
+    +-------- PresentationAndUpdate -------->|
+    |<-------------- Update? ----------------+
+Finalize                                    |
     |                                        |
 ~~~
 {: #fig-credential-flow title="Redeem & Issue, then presentation and update"}
 
-Both parts ride on HTTP requests to the Moderator, since each is an
-authorization. Redeem & Issue carries a `CredentialRequest` in the
+Both parts ride on HTTP requests to the Moderator. Redeem & Issue carries a
+`CredentialRequest` in the
 `Authorization` header and receives the `CredentialResponse` in the
-`Mole-Credential` response header. Presentation uses the same
-authentication scheme, with the update returned in the same
-`Mole-Credential` header under its `update` parameter. Carriage is
-defined in {{HTTP-TRANSPORT}}.
+`Mole-Credential` response header. The Moderator runs the selected endorsement
+protocol's `FinalizeRedeem` operation before processing the issuance request.
+Presentation uses the same authentication scheme.
 
 ~~~ tls-presentation
 struct {
   uint16 endorsement_type;
-  opaque endorsement_presentation<V>;
+  opaque endorsement_presentation<V>; /* encoded Redemption */
   uint16 credential_type;
   opaque issuance_request<V>;
 } CredentialRequest;
@@ -459,18 +543,71 @@ struct {
 } CredentialResponse;
 ~~~
 
-The `endorsement_presentation` field carries the `Presentation` structure
-of the named endorsement type. With `endorsement_type` 0x0001 it is empty,
-and the Moderator relies on its own trust establishment ({{common}}).
+The structure fields are:
 
-Every credential protocol defines five structures. `Challenge` is the
-type-specific content of the Moderator's challenge, carried in its
-`challenge` field ({{HTTP-TRANSPORT}}). `IssuanceRequest` and
-`IssuanceResponse` fill the `issuance_request` and `issuance_response`
-fields above. `PresentationAndUpdate` is carried in the
-`presentation_and_update` field of a `CredentialPresentation`
-({{HTTP-TRANSPORT}}). `Update` is returned in the `update` parameter of
-the `Mole-Credential` header.
+* `endorsement_type` identifies the endorsement protocol.
+* `endorsement_presentation` is its encoded `Redemption`. It is empty for
+  endorsement type 0x0001 ({{no-endorsement-required}}).
+* `credential_type` identifies the credential protocol.
+* `issuance_request` is its encoded `IssuanceRequest`.
+* `issuance_response` is its encoded `IssuanceResponse`.
+
+A recipient of `CredentialResponse` MUST reject it unless `credential_type`
+matches the type selected by `CredentialRequest`.
+
+All credential protocols define the same four payloads:
+
+IssuanceRequest
+: A Client-generated request for a new Credential.
+
+IssuanceResponse
+: The Moderator's response to `IssuanceRequest`.
+
+PresentationAndUpdate
+: A presentation of a Credential and any request needed to replace or update
+  it.
+
+Update
+: The Moderator's response to `PresentationAndUpdate`, when the Client remains
+  eligible for a Credential.
+
+The type-specific encodings fill the opaque fields of the outer structures
+above and of `CredentialPresentation` and `CredentialUpdate` from
+{{HTTP-TRANSPORT}}.
+
+## Abstract Credential API
+
+Each credential protocol defines these abstract operations:
+
+~~~
+CreateIssuanceRequest(moderator_challenge, configuration)
+  -> (issuance_state, issuance_request) | INVALID
+IssueCredential(issuance_request, moderator_challenge, policy, configuration)
+  -> issuance_response | INVALID
+FinalizeIssuance(issuance_state, issuance_response, configuration)
+  -> credential | INVALID
+
+CreatePresentationAndUpdate(credential, credential_challenge, configuration)
+  -> (presentation_state, presentation_and_update) | INVALID
+ProcessPresentation(
+    presentation_and_update, credential_challenge, policy, configuration)
+  -> INVALID
+   | ACCEPTED_NO_UPDATE
+   | ACCEPTED_WITH_UPDATE(update)
+FinalizeUpdate(presentation_state, update, configuration)
+  -> credential | INVALID
+~~~
+
+`CreateIssuanceRequest`, `FinalizeIssuance`, `CreatePresentationAndUpdate`, and
+`FinalizeUpdate` run at the Client. `IssueCredential` and `ProcessPresentation`
+run at the Moderator. State values are local and are not sent on the wire.
+`ACCEPTED_NO_UPDATE` means that the presentation succeeded but the Credential
+was consumed without replacement. `ACCEPTED_WITH_UPDATE` carries the encoded
+`Update` that the Client finalizes into its replacement Credential by calling
+`FinalizeUpdate`. The Client does not call `FinalizeUpdate` for
+`ACCEPTED_NO_UPDATE`. A complete protocol specification defines its Context
+derivation, replay protection, and retry behavior. The Moderator completes that
+replay protection before returning an accepted result.
 
 ## Anonymous Credit Tokens (ACT) {#credential-act}
 
@@ -478,8 +615,8 @@ Credential type: 0x0001.
 
 An ACT credential {{ACT}} is an anonymous state machine: the Moderator can
 test a predicate against the Credential's hidden state and update that
-state, without learning the state or linking presentations. This is the
-credential protocol that provides every property required by
+state, without learning the state or linking presentations. This protocol is
+intended to provide every property required by
 {{ARCHITECTURE}}, including that updates provably apply to the credential
 that was presented.
 
@@ -501,19 +638,23 @@ struct {
 } IssuanceResponse;
 ~~~
 
-The `request` and `response` fields are defined in {{ACT}}. The Client
-finalizes the response into a Credential with an initial state chosen by
-the Moderator's policy.
+The structure fields are:
+
+* `truncated_key_id` selects the configured ACT key.
+* `request` is the encoded ACT issuance request.
+* `response` is the encoded ACT issuance response.
+
+These structures are intended to implement `CreateIssuanceRequest`,
+`IssueCredential`, and `FinalizeIssuance`.
 
 ### Presentation and Update
 
-The Client presents the Credential against the challenged predicate,
+The Client presents the Credential against the selected predicate,
 spending it, and in the same message requests the replacement that carries
 the updated state.
 
 ~~~ tls-presentation
 struct {
-  opaque challenge_digest[32];
   opaque key_id[32];
   opaque spend_proof<V>;
 } PresentationAndUpdate;
@@ -523,48 +664,42 @@ struct {
 } Update;
 ~~~
 
-The `spend_proof` and `refund` fields are defined in {{ACT}}. The
-Moderator verifies the spend proof and learns whether the Credential's
-hidden state satisfies the challenged predicate. For range-style
-predicates, this necessarily reveals the public bound being tested, but
-not the hidden state value. The Client finalizes the refund into its new
-Credential. ACT guarantees the refund applies to the state that was
-presented.
+The structure fields are:
 
-TODO: the exact mapping between the spend and refund operations of {{ACT}}
-and MoLE's predicate and update is not settled. In particular, `Challenge`
-for this type must express the predicate and the charged amount, and its
-contents are not yet defined.
+* `key_id` identifies the ACT key.
+* `spend_proof` is the encoded ACT spend proof.
+* `refund` is the encoded ACT refund.
 
-The `Challenge` for this type therefore needs to identify the predicate,
-including any public bound, and the update to apply.
+These structures are intended to implement `CreatePresentationAndUpdate`,
+`ProcessPresentation`, and `FinalizeUpdate`.
+
+> **Editor note.** The mapping from ACT issuance, spend, and refund operations
+> to MoLE Contexts and payloads is undefined. This protocol is not interoperable
+> until that mapping and its canonical encodings are specified.
 
 ## Privacy Pass with a Reverse Flow {#credential-reverse}
 
 Credential type: 0x0002.
 
-The Credential is a single privately verifiable Privacy Pass token. Any
-token type registered in the Privacy Pass Token Types registry
-({{PRIVACYPASS-PROTOCOLS}}) can be used. The Moderator's configuration
-names one. The Credential encodes one bit: the Client either holds a valid
-token or it does not. Presentation consumes the token. The update, if
-granted, is a fresh token issued through the reverse flow of
-{{REVERSE-FLOW}}, with the Moderator acting as both initial and reverse
-issuer.
+The Credential is a single Privacy Pass token. The Moderator's configuration
+names both the registered token type used for presentation and the registered
+token type used for update issuance. Presentation consumes the token. The
+update, if granted, is a fresh token issued through {{REVERSE-FLOW}}, with
+redemption in place of attestation.
 
-The presented and reissued token MUST use the same token type and the same
-Moderator public key. Anything else partitions Clients and leaks state.
+For the protocol described here, the presented and reissued token use the same
+token type and Moderator key. Changing either partitions Clients and leaks
+state.
 
 ### Redeem & Issue
 
 `IssuanceRequest` is a `TokenRequest` and `IssuanceResponse` is a
 `TokenResponse`, both as defined for the configured token type in
-{{PRIVACYPASS-PROTOCOLS}}. The finalized token is the Credential.
+{{PRIVACYPASS-PROTOCOLS}}. That token type's finalization operation produces
+the Credential. These messages implement `CreateIssuanceRequest`,
+`IssueCredential`, and `FinalizeIssuance`.
 
 ### Presentation and Update
-
-`Challenge` is empty for this type. The challenge octets, and therefore
-`challenge_digest`, are constant for a given Moderator configuration.
 
 ~~~ tls-presentation
 struct {
@@ -577,17 +712,50 @@ struct {
 } Update;
 ~~~
 
-The `token` field carries a `Token` as defined in {{PRIVACYPASS-AUTH}}.
-Its `challenge_digest` field is fixed when the token is issued, one
-exchange before it is presented, and MUST equal the Moderator's constant
-`challenge_digest` ({{challenge-binding}}). This binds the token to the
-Moderator, not to the exchange that presents it. Anti-replay therefore
-does not come from challenge binding: it comes from the token being
-single-use. The Moderator MUST reject a token whose nonce it has already
-seen.
+The structure fields are:
 
-If the Moderator's policy allows continued access, it returns an `Update`.
-If not, it returns an empty update and the Client is out of credentials.
+* `token` is the presented Privacy Pass `Token`.
+* `token_request` is the encoded replacement `TokenRequest`.
+* `token_response` is the encoded replacement `TokenResponse`.
+
+These structures implement `CreatePresentationAndUpdate`, `ProcessPresentation`,
+and `FinalizeUpdate`.
+
+The `token` field carries a `Token` as defined in {{PRIVACYPASS-AUTH}}.
+Privacy Pass names its cryptographic Context `TokenChallenge`. In MoLE, the
+type-specific body of `CredentialChallenge` carries that configured
+`TokenChallenge`. It is therefore both sent by the Moderator as part of a
+Challenge and supplied to the Privacy Pass replacement-issuance and
+verification operations as their Context. Initial issuance obtains the same
+`TokenChallenge` from authenticated configuration.
+
+`TokenChallenge` is fixed when the token is issued. It MUST be stable for every
+Client using the same configured credential type, key, and epoch, and MUST NOT
+contain a per-Client or per-request value. This is necessary because a
+replacement token is issued before the operation in which it will be
+presented.
+The Privacy Pass `Token.challenge_digest` field MUST equal SHA-256 over the
+encoded configured `TokenChallenge`. It is distinct from the MoLE endorsement
+`challenge_digest` defined in {{challenge-binding}}. The Moderator MUST reject
+a token carrying any other digest. Replay protection comes from token single use.
+The Moderator MUST verify the token as specified by {{PRIVACYPASS-AUTH}}
+against the configured token type, key, and `TokenChallenge`, then atomically
+record its nonce before accepting it. An invalid or previously recorded nonce
+is rejected, except for the retry behavior below. Holder binding remains an
+open limitation below.
+
+If the Moderator's policy allows continued access, it returns an `Update`. If
+not, it returns no update and the Client is out of credentials.
+
+### Retry after a lost response
+
+A Client that receives no response MAY retry the byte-identical
+`PresentationAndUpdate` only to recover from that loss. The Moderator MUST
+return the same accepted result while it retains the idempotency record,
+including the same `Update` or the same absence of an update. It MUST reject the
+replay after that record expires and MUST NOT issue a second Credential. The
+Client MUST NOT combine the same presented Credential with a different update
+request. These requirements are the retry semantics of {{REVERSE-FLOW}}.
 
 ### Limitations
 
@@ -595,100 +763,16 @@ TODO: define a device binding mechanism, issuing tokens bound to a Client
 key so that presentation requires proof of possession. This would restore
 the binding between update and presented credential. Open problem.
 
-## Budget Privacy Pass {#credential-budget}
-
-Credential type: 0x0003.
-
-The Credential is a balance, represented as Privacy Pass tokens drawn from
-N issuers operated by the same Moderator, where issuer i denominates 2^i
-units. Tokens are issued in batches using {{PRIVACYPASS-BATCHED}}, and any
-token type registered in the Privacy Pass Token Types registry that
-supports batched issuance can be used. The Client presents whatever tokens
-it wants, and the sum of their denominations is the amount spent. The
-Moderator returns change and any policy adjustment as freshly issued
-tokens through the reverse flow, summing to the intended new balance.
-
-A presentation reveals that the Client can spend the challenged amount. If
-the protocol presents exactly one token for that amount, and balance
-management remains Client-local, this is the same disclosure as an ACT
-predicate over that amount: the Moderator learns the predicate result, not
-the Client's remaining balance. Deployments that allow multiple tokens,
-variable denominations, or observable change shapes need padding or another
-mitigation.
-
-### Redeem & Issue
-
-`IssuanceRequest` is a `BatchTokenRequest` and `IssuanceResponse` is a
-`BatchTokenResponse` ({{PRIVACYPASS-BATCHED}}), for tokens summing to the
-initial balance set by the Moderator's policy.
-
-### Presentation and Update
-
-The challenge indicates the amount to spend:
-
-~~~ tls-presentation
-struct {
-  uint64 amount;
-} Challenge;
-~~~
-
-The `amount` is an indicator, not a per-Client value. A Moderator MUST
-use the same amount for every Client under a policy: varying it
-partitions Clients. Deployments MAY publish the amount out of band
-instead ({{key-rotation}}), in which case the field repeats the published
-value.
-
-~~~ tls-presentation
-struct {
-  opaque tokens<V>;         /* one or more Tokens */
-  opaque token_request<V>;  /* BatchTokenRequest */
-} PresentationAndUpdate;
-
-struct {
-  opaque token_response<V>; /* BatchTokenResponse */
-} Update;
-~~~
-
-Challenge binding comes from each `Token` structure, as in
-{{credential-reverse}}. The Client MAY at any time exchange several small
-tokens for larger ones at the Moderator's refund endpoint.
-
-### When to use it
-
-Balances with many possible values need many tokens and padding traffic to
-avoid leaking through request counts. If the state fits an ACT credential,
-{{credential-act}} is simpler and leaks less. This protocol fits
-deployments that already run Privacy Pass issuers and need only coarse
-balances.
-
 # Key Rotation and Discovery {#key-rotation}
 
-TODO.
+This draft assumes authenticated configuration supplies endpoints, supported
+types, keys, epochs, accepted issuer sets, and type-specific inputs. The order
+of accepted sets is significant because IHAT proof branches and Longfellow
+issuer inputs match elements by position.
 
-Anchors and Moderators each publish a configuration that Clients fetch
-before running any flow. It contains their endpoints, supported endorsement
-and credential types, public keys, and, for Moderators, the accepted Anchor
-set for each policy. The order of the accepted set is normative: IHAT
-OR proofs and Longfellow issuer sets match elements by position, so all
-parties must see the same order.
-
-Endorsements live in epochs. The `endorsement_context` of IHAT and the
-epoch of Longfellow name the epoch an Endorsement is granted in, which is
-also the window the Moderator's nullifier store covers. Epoch length is a
-privacy parameter: short epochs shrink the double-spend store but
-partition Clients into smaller anonymity sets. See {{ARCHITECTURE}} for
-the consistency requirements on configuration. A Moderator that shows
-different configurations to different Clients can partition them.
-
-Open questions:
-
-1. Format: a Privacy Pass style directory, or JWKS. Reusing JWKS matters if
-   deployments want existing key-management tooling, despite feelings.
-2. How and when Anchor and Moderator keys rotate.
-3. Whether messages carry a key identifier, such as a truncated key
-   identifier as in Privacy Pass token requests, or a JWK Thumbprint.
-4. How Clients validate Moderator configuration without revealing
-   themselves, and how consistency is audited.
+> **Editor note.** Configuration discovery, serialization, authentication,
+> canonical encodings, consistency, and rotation remain undefined. The wire
+> protocols are not interoperable until these are specified.
 
 # Privacy Considerations {#privacy-considerations}
 
@@ -719,26 +803,40 @@ TODO. The list to cover:
 4. Timing and error side channels during verification, especially
    distinguishing "bad proof" from "spent nullifier".
 
+The replay protection store is shared only within its configured scope. A
+deployment can use one atomic scope across all regions, including by routing
+each replay protection identifier to an authoritative region. This does not
+require the Client to know that region. A deployment can instead operate
+independent regional stores, but then the same Endorsement can be accepted once
+in each region. Credentials can likewise be presented once in each region,
+potentially creating divergent updates. Separate Moderators also do not
+coordinate stores.
+An IHAT redemption exposes the same nullifier in each scope, making cross-scope
+reuse linkable if records are compared. Proof rerandomization does not hide that
+reuse.
+
 # IANA Considerations {#iana}
 
 This document sketches two candidate registries under a future "MoLE"
 group. The values below are candidate values for discussion in this -00
 draft and are not stable assignments.
 
-A registration MUST define the per-type structures its flow requires:
-`Challenge` and `Presentation` for endorsement types
-({{endorsement-protocols}}), and `Challenge`, `IssuanceRequest`,
-`IssuanceResponse`, `PresentationAndUpdate`, and `Update` for credential
-types ({{credential-protocols}}). Every message begins with the registered
-`uint16` type ({{common}}). A registration MUST also state how redemption
-or presentation binds `challenge_digest` ({{challenge-binding}}).
+New registrations use Specification Required as defined by {{IANA}}. A
+specification MUST define the structures and abstract operations required by
+the relevant common API, including canonical encodings and maximum sizes. An
+endorsement registration MUST provide issuer hiding where applicable, define
+its replay protection behavior, and state how a Challenge affects its cryptographic
+Context. A credential registration MUST define `IssuanceRequest`,
+`IssuanceResponse`, `PresentationAndUpdate`, `Update`, finalization, retry
+behavior, and Challenge-to-Context derivation. Outer type-selecting messages
+carry the registered `uint16` type as specified in {{common}}.
 
 ## MoLE Endorsement Types
 
 | Value           | Name                          | Reference      |
 |:----------------|:------------------------------|:---------------|
 | 0x0000          | Reserved                      | this document  |
-| 0x0001          | Moderator trust establishment | {{common}}     |
+| 0x0001          | No Endorsement Required       | {{no-endorsement-required}} |
 | 0x0002          | IHAT                          | {{ihat}}       |
 | 0x0003          | Longfellow                    | {{longfellow}} |
 | 0xFF00 - 0xFFFF | Reserved for testing          | this document  |
@@ -774,12 +872,14 @@ The following initial registrations are candidates only.
 
 ## MoLE Credential Types
 
+One MoLE credential type identifies the issuance, presentation, and update
+payloads defined by a credential protocol.
+
 | Value           | Name                       | Reference             |
 |:----------------|:---------------------------|:----------------------|
 | 0x0000          | Reserved                   | this document         |
 | 0x0001          | ACT                        | {{credential-act}}    |
 | 0x0002          | Privacy Pass Reverse Flow  | {{credential-reverse}} |
-| 0x0003          | Budget Privacy Pass        | {{credential-budget}} |
 | 0x0A0A, 0x1A1A, ..., 0xFAFA | Reserved for greasing | {{greasing}} |
 | 0xFF00 - 0xFFFF | Reserved for testing       | this document         |
 {: #credential-types title="Candidate MoLE Credential Type Values"}
@@ -806,13 +906,6 @@ The registration template contains:
 * Bound Update: No
 * Reference: {{credential-reverse}}
 
-### Budget Privacy Pass {#iana-budget}
-
-* Value: 0x0003
-* Name: Budget Privacy Pass
-* Bound Update: No
-* Reference: {{credential-budget}}
-
 ### Greased Values {#iana-grease}
 
 * Value: 0x0A0A, 0x1A1A, 0x2A2A, 0x3A3A, 0x4A4A, 0x5A5A, 0x6A6A, 0x7A7A,
@@ -832,7 +925,8 @@ random bytes ({{greasing}}).
 | application/mole-endorsement-response | {{endorsement-protocols}} |
 {: #media-types-table title="MoLE Media Types"}
 
-TODO: full registration templates, following the Privacy Pass template.
+> **Editor note.** The final registry names and expert-review instructions
+> remain to be specified.
 
 
 --- back
@@ -841,55 +935,50 @@ TODO: full registration templates, following the Privacy Pass template.
 
 A Client requests a resource protected by a Moderator that uses credential
 type 0x0002 (Privacy Pass Reverse Flow) and accepts endorsement type
-0x0002 (IHAT).
+0x0002 (IHAT). The Client obtains the Endorsement before contacting that
+Moderator.
 
 ~~~ aasvg
 +--------+         +--------+      +-----------+
 | Client |         | Anchor |      | Moderator |
 +---+----+         +---+----+      +-----+-----+
     |                  |                 |
-    +------------------|---- request --->|
-    |<-----------------|--- challenge ---+
-    +--- exchange 1 -->|                 |
-    |<-- response 1 ---+                 |
-    +--- exchange 2 -->|                 |
-    |<-- response 2 ---+                 |
+    +--- empty body --->|                |
+    |<-- CommitMessage -+                |
+    +-- ChallengeMessage -->|            |
+    |<-- ResponseMessage ---+            |
 Finalize               |                 |
-    +------------------|---- redeem ---->|
-    |<-----------------|---- credential -+
+    |<-------- ModeratorChallenge -------+
+    |   Redemption + IssuanceRequest      |
+    +------------------------------------>|
+    |<------------------------------------+
+    |   IssuanceResponse                  |
 Finalize               |                 |
-    +------------------|---- present --->|
-    |<-----------------|-- ok + update --+
+    |<-------- CredentialChallenge ------+
+    |   PresentationAndUpdate             |
+    +------------------------------------>|
+    |<------------------------------------+
+    |   Update                            |
     |                  |                 |
 ~~~
 {: #fig-example title="Complete exchange"}
 
-The Moderator challenges the Client:
+The first IHAT request has an empty body. The Anchor returns a
+`CommitMessage`. The Client then sends the corresponding `ChallengeMessage`,
+and the Anchor returns a `ResponseMessage`:
 
 ~~~
-HTTP/1.1 401 Unauthorized
-WWW-Authenticate: Mole challenge="<credential-challenge>",
-                       realm="moderator"
-~~~
-
-The Client holds no Credential for this Moderator, so it first obtains an
-Endorsement. It runs the two IHAT exchanges against the Anchor:
-
-~~~
-POST /mole/endorse HTTP/1.1
+POST <anchor-grant-link> HTTP/1.1
 Host: anchor.example
 Content-Type: application/mole-endorsement-request
 
-EndorsementRequest { 0x0002, Prepare(...) }
+EndorsementRequest { 0x0002, "" }
 ~~~
 
-The Anchor answers each POST with an
-`application/mole-endorsement-response` body, and the Client finalizes the
-Endorsement.
-
-The Client then runs Redeem & Issue. It repeats its request, this time
-carrying a `CredentialRequest` that redeems the Endorsement bound to the
-Moderator's challenge together with a Privacy Pass TokenRequest:
+The Client finalizes the `ResponseMessage` into an Endorsement. It then obtains
+a `ModeratorChallenge` from the Moderator, computes its digest, and sends an
+HTTP request with a `CredentialRequest` containing the IHAT `Redemption` and a
+Privacy Pass `TokenRequest`:
 
 ~~~
 GET /resource HTTP/1.1
@@ -897,10 +986,13 @@ Host: moderator.example
 Authorization: Mole credential-request="<credential-request>"
 ~~~
 
-The Moderator verifies the redemption, records its nullifier, and returns
-a `CredentialResponse` carrying a TokenResponse in the `Mole-Credential`
-header, alongside its unchanged challenge. The Client finalizes it into a
-token and answers the challenge:
+The Moderator verifies the redemption against the Challenge it sent and
+atomically records its nullifier.
+It then processes the issuance request and returns a `CredentialResponse`
+carrying a `TokenResponse` in the `Mole-Credential` header. The Client finalizes
+the issuance response. On a later request, it obtains a
+`CredentialChallenge` carrying the configured Privacy Pass `TokenChallenge`
+before presenting the resulting token:
 
 ~~~
 GET /resource HTTP/1.1
@@ -908,9 +1000,8 @@ Host: moderator.example
 Authorization: Mole presentation="<credential-presentation>"
 ~~~
 
-The Moderator verifies the presentation and serves the resource. Its
-response carries a `Mole-Credential` header whose `update` parameter
-holds a fresh token, or an absent update if it chose to consume the
+The Moderator verifies the presentation and serves the resource. Its response
+carries an `Update` for a fresh token, or no update if it chose to consume the
 Credential.
 
 # Acknowledgments


### PR DESCRIPTION
Updating the protocol draft to start aligning with the evolution of the crypto drafts (IHAT and longfellow #59).

Main changes are:
1. Defines common abstract APIs for endorsement and credential protocols
2. Update the vocabulary to better characterise "context", especially as that's used in a couple of places
3. Removes Budget Privacy Pass (not planned to be implemented)
4. Ensure that behaviour that we don't know about yet (ihat, longfellow, act, reverse flow) is clearly marked as such

The protocols are not yet fully backed for interroperability, but having reviews on the API shape would help.